### PR TITLE
MLJ 0.17 update for tutorial 03: .jl, .ipynb (new), .unexecuted.ipynb

### DIFF
--- a/notebooks/03_pipelines/env/Manifest.toml
+++ b/notebooks/03_pipelines/env/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.7.1"
+julia_version = "1.6.5"
 manifest_format = "2.0"
 
 [[deps.ARFFFiles]]
@@ -17,9 +17,9 @@ version = "1.0.1"
 
 [[deps.Adapt]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "9faf218ea18c51fcccaf956c8d39614c9d30fe8b"
+git-tree-sha1 = "af92965fb30777147966f58acb05da51c5616b5f"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "3.3.2"
+version = "3.3.3"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -90,9 +90,9 @@ version = "0.1.4"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "d711603452231bad418bd5e0c91f1abd650cba71"
+git-tree-sha1 = "926870acb6cbcf029396f2f2de030282b6bc1941"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.11.3"
+version = "1.11.4"
 
 [[deps.ChangesOfVariables]]
 deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
@@ -429,7 +429,7 @@ uuid = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
 version = "7.1.1"
 
 [[deps.LinearAlgebra]]
-deps = ["Libdl", "libblastrampoline_jll"]
+deps = ["Libdl"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.LinearMaps]]
@@ -570,9 +570,9 @@ version = "0.3.6"
 
 [[deps.NetworkLayout]]
 deps = ["GeometryBasics", "LinearAlgebra", "Random", "Requires", "SparseArrays"]
-git-tree-sha1 = "24e10982e84dd35cd867102243454bf8a4581a76"
+git-tree-sha1 = "cac8fc7ba64b699c678094fa630f49b80618f625"
 uuid = "46757867-2c16-5918-afeb-47bfcb05e46a"
-version = "0.4.3"
+version = "0.4.4"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -680,7 +680,7 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.Random]]
-deps = ["SHA", "Serialization"]
+deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[deps.Random123]]
@@ -898,10 +898,6 @@ version = "1.4.1"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-
-[[deps.libblastrampoline_jll]]
-deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
-uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/notebooks/03_pipelines/env/Manifest.toml
+++ b/notebooks/03_pipelines/env/Manifest.toml
@@ -1,894 +1,912 @@
 # This file is machine-generated - editing it directly is not advised
 
-[[ARFFFiles]]
-deps = ["CategoricalArrays", "Dates", "Parsers", "Tables"]
-git-tree-sha1 = "3556fa90c0bea9f965388c0e123418cb9f5ff2e3"
-uuid = "da404889-ca92-49ff-9e8b-0aa6b4d38dc8"
-version = "1.4.0"
+julia_version = "1.7.1"
+manifest_format = "2.0"
 
-[[AbstractFFTs]]
+[[deps.ARFFFiles]]
+deps = ["CategoricalArrays", "Dates", "Parsers", "Tables"]
+git-tree-sha1 = "e8c8e0a2be6eb4f56b1672e46004463033daa409"
+uuid = "da404889-ca92-49ff-9e8b-0aa6b4d38dc8"
+version = "1.4.1"
+
+[[deps.AbstractFFTs]]
 deps = ["LinearAlgebra"]
 git-tree-sha1 = "485ee0867925449198280d4af84bdb46a2a404d0"
 uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 version = "1.0.1"
 
-[[Adapt]]
+[[deps.Adapt]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "84918055d15b3114ede17ac6a7182f68870c16f7"
+git-tree-sha1 = "9faf218ea18c51fcccaf956c8d39614c9d30fe8b"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "3.3.1"
+version = "3.3.2"
 
-[[ArgTools]]
+[[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 
-[[Arpack]]
+[[deps.Arpack]]
 deps = ["Arpack_jll", "Libdl", "LinearAlgebra"]
 git-tree-sha1 = "2ff92b71ba1747c5fdd541f8fc87736d82f40ec9"
 uuid = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 version = "0.4.0"
 
-[[Arpack_jll]]
+[[deps.Arpack_jll]]
 deps = ["Libdl", "OpenBLAS_jll", "Pkg"]
 git-tree-sha1 = "e214a9b9bd1b4e1b4f15b22c0994862b66af7ff7"
 uuid = "68821587-b530-5797-8361-c406ea357684"
 version = "3.5.0+3"
 
-[[ArrayInterface]]
+[[deps.ArrayInterface]]
 deps = ["Compat", "IfElse", "LinearAlgebra", "Requires", "SparseArrays", "Static"]
-git-tree-sha1 = "d9352737cef8525944bf9ef34392d756321cbd54"
+git-tree-sha1 = "1ee88c4c76caa995a885dc2f22a5d548dfbbc0ba"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "3.1.38"
+version = "3.2.2"
 
-[[Artifacts]]
+[[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
-[[BFloat16s]]
+[[deps.BFloat16s]]
 deps = ["LinearAlgebra", "Printf", "Random", "Test"]
 git-tree-sha1 = "a598ecb0d717092b5539dbbe890c98bac842b072"
 uuid = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"
 version = "0.2.0"
 
-[[BSON]]
+[[deps.BSON]]
 git-tree-sha1 = "ebcd6e22d69f21249b7b8668351ebf42d6dc87a1"
 uuid = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
 version = "0.3.4"
 
-[[Base64]]
+[[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[CEnum]]
+[[deps.CEnum]]
 git-tree-sha1 = "215a9aa4a1f23fbd05b92769fdd62559488d70e9"
 uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 version = "0.4.1"
 
-[[CSV]]
+[[deps.CSV]]
 deps = ["CodecZlib", "Dates", "FilePathsBase", "InlineStrings", "Mmap", "Parsers", "PooledArrays", "SentinelArrays", "Tables", "Unicode", "WeakRefStrings"]
-git-tree-sha1 = "74147e877531d7c172f70b492995bc2b5ca3a843"
+git-tree-sha1 = "49f14b6c56a2da47608fe30aed711b5882264d7a"
 uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
-version = "0.9.10"
+version = "0.9.11"
 
-[[CUDA]]
+[[deps.CUDA]]
 deps = ["AbstractFFTs", "Adapt", "BFloat16s", "CEnum", "CompilerSupportLibraries_jll", "ExprTools", "GPUArrays", "GPUCompiler", "LLVM", "LazyArtifacts", "Libdl", "LinearAlgebra", "Logging", "Printf", "Random", "Random123", "RandomNumbers", "Reexport", "Requires", "SparseArrays", "SpecialFunctions", "TimerOutputs"]
-git-tree-sha1 = "2c8329f16addffd09e6ca84c556e2185a4933c64"
+git-tree-sha1 = "429a1a05348ce948a96adbdd873fbe6d9e5e052f"
 uuid = "052768ef-5323-5732-b1bb-66c8b64840ba"
-version = "3.5.0"
+version = "3.6.2"
 
-[[CategoricalArrays]]
+[[deps.CategoricalArrays]]
 deps = ["DataAPI", "Future", "Missings", "Printf", "Requires", "Statistics", "Unicode"]
-git-tree-sha1 = "fbc5c413a005abdeeb50ad0e54d85d000a1ca667"
+git-tree-sha1 = "c308f209870fdbd84cb20332b6dfaf14bf3387f8"
 uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-version = "0.10.1"
+version = "0.10.2"
 
-[[ChainRulesCore]]
+[[deps.CategoricalDistributions]]
+deps = ["CategoricalArrays", "Distributions", "Missings", "OrderedCollections", "Random", "ScientificTypesBase", "UnicodePlots"]
+git-tree-sha1 = "a5734a58e5dc8c749b5507d03ba5e457d077181b"
+uuid = "af321ab8-2d2e-40a6-b165-3d674595d28e"
+version = "0.1.4"
+
+[[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "3533f5a691e60601fe60c90d8bc47a27aa2907ec"
+git-tree-sha1 = "d711603452231bad418bd5e0c91f1abd650cba71"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.11.0"
+version = "1.11.3"
 
-[[CodecZlib]]
+[[deps.ChangesOfVariables]]
+deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
+git-tree-sha1 = "bf98fa45a0a4cee295de98d4c1462be26345b9a1"
+uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+version = "0.1.2"
+
+[[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
 git-tree-sha1 = "ded953804d019afa9a3f98981d99b33e3db7b6da"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
 version = "0.7.0"
 
-[[ColorTypes]]
+[[deps.ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
 git-tree-sha1 = "024fe24d83e4a5bf5fc80501a314ce0d1aa35597"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 version = "0.11.0"
 
-[[CommonSubexpressions]]
+[[deps.CommonSubexpressions]]
 deps = ["MacroTools", "Test"]
 git-tree-sha1 = "7b8a93dba8af7e3b42fecabf646260105ac373f7"
 uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
 version = "0.3.0"
 
-[[Compat]]
+[[deps.Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "dce3e3fea680869eaa0b774b2e8343e9ff442313"
+git-tree-sha1 = "44c37b4636bc54afac5c574d2d02b625349d6582"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.40.0"
+version = "3.41.0"
 
-[[CompilerSupportLibraries_jll]]
+[[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 
-[[ComputationalResources]]
+[[deps.ComputationalResources]]
 git-tree-sha1 = "52cb3ec90e8a8bea0e62e275ba577ad0f74821f7"
 uuid = "ed09eef8-17a6-5b46-8889-db040fac31e3"
 version = "0.3.2"
 
-[[Crayons]]
-git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
+[[deps.Crayons]]
+git-tree-sha1 = "b618084b49e78985ffa8422f32b9838e397b9fc2"
 uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
-version = "4.0.4"
+version = "4.1.0"
 
-[[DataAPI]]
+[[deps.DataAPI]]
 git-tree-sha1 = "cc70b17275652eb47bc9e5f81635981f13cea5c8"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 version = "1.9.0"
 
-[[DataFrames]]
+[[deps.DataFrames]]
 deps = ["Compat", "DataAPI", "Future", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "Markdown", "Missings", "PooledArrays", "PrettyTables", "Printf", "REPL", "Reexport", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
-git-tree-sha1 = "d785f42445b63fc86caa08bb9a9351008be9b765"
+git-tree-sha1 = "cfdfef912b7f93e4b848e80b9befdf9e331bc05a"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "1.2.2"
+version = "1.3.1"
 
-[[DataStructures]]
+[[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "7d9d316f04214f7efdbb6398d545446e246eff02"
+git-tree-sha1 = "3daef5523dd2e769dad2365274f760ff5f282c7d"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.10"
+version = "0.18.11"
 
-[[DataValueInterfaces]]
+[[deps.DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
 uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
 version = "1.0.0"
 
-[[Dates]]
+[[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
-[[DelimitedFiles]]
+[[deps.DelimitedFiles]]
 deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
-[[DiffResults]]
+[[deps.DensityInterface]]
+deps = ["InverseFunctions", "Test"]
+git-tree-sha1 = "80c3e8639e3353e5d2912fb3a1916b8455e2494b"
+uuid = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
+version = "0.4.0"
+
+[[deps.DiffResults]]
 deps = ["StaticArrays"]
 git-tree-sha1 = "c18e98cba888c6c25d1c3b048e4b3380ca956805"
 uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
 version = "1.0.3"
 
-[[DiffRules]]
-deps = ["NaNMath", "Random", "SpecialFunctions"]
-git-tree-sha1 = "7220bc21c33e990c14f4a9a319b1d242ebc5b269"
+[[deps.DiffRules]]
+deps = ["LogExpFunctions", "NaNMath", "Random", "SpecialFunctions"]
+git-tree-sha1 = "9bc5dac3c8b6706b58ad5ce24cffd9861f07c94f"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "1.3.1"
+version = "1.9.0"
 
-[[Distances]]
-deps = ["LinearAlgebra", "Statistics", "StatsAPI"]
-git-tree-sha1 = "837c83e5574582e07662bbbba733964ff7c26b9d"
+[[deps.Distances]]
+deps = ["LinearAlgebra", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "3258d0659f812acde79e8a74b11f17ac06d0ca04"
 uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
-version = "0.10.6"
+version = "0.10.7"
 
-[[Distributed]]
+[[deps.Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
-[[Distributions]]
-deps = ["ChainRulesCore", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SparseArrays", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns"]
-git-tree-sha1 = "d249ebaa67716b39f91cf6052daf073634013c0f"
+[[deps.Distributions]]
+deps = ["ChainRulesCore", "DensityInterface", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SparseArrays", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns", "Test"]
+git-tree-sha1 = "6a8dc9f82e5ce28279b6e3e2cea9421154f5bd0d"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
-version = "0.25.23"
+version = "0.25.37"
 
-[[DocStringExtensions]]
+[[deps.DocStringExtensions]]
 deps = ["LibGit2"]
 git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.8.6"
 
-[[Downloads]]
+[[deps.Downloads]]
 deps = ["ArgTools", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
-[[EarCut_jll]]
+[[deps.EarCut_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "3f3a2501fa7236e9b911e0f7a588c657e822bb6d"
 uuid = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"
 version = "2.2.3+0"
 
-[[EarlyStopping]]
+[[deps.EarlyStopping]]
 deps = ["Dates", "Statistics"]
-git-tree-sha1 = "ea0b56527cefce87419d4b7559811bd96974a6c8"
+git-tree-sha1 = "98fdf08b707aaf69f524a6cd0a67858cefe0cfb6"
 uuid = "792122b4-ca99-40de-a6bc-6742525f08b6"
-version = "0.1.9"
+version = "0.3.0"
 
-[[EvoTrees]]
-deps = ["BSON", "CUDA", "CategoricalArrays", "Distributions", "MLJModelInterface", "NetworkLayout", "Random", "RecipesBase", "StaticArrays", "Statistics", "StatsBase"]
-git-tree-sha1 = "556a81b4b1bd7a317c82ffc595ed0fe9fcd03d85"
+[[deps.EvoTrees]]
+deps = ["BSON", "CUDA", "CategoricalArrays", "Distributions", "MLJModelInterface", "NetworkLayout", "Random", "RecipesBase", "SpecialFunctions", "StaticArrays", "Statistics", "StatsBase"]
+git-tree-sha1 = "d1d91fd0643d6eb7946c15115b625b0b1e1a5393"
 uuid = "f6006082-12f8-11e9-0c9c-0d5d367ab1e5"
-version = "0.8.5"
+version = "0.9.1"
 
-[[ExprTools]]
+[[deps.ExprTools]]
 git-tree-sha1 = "b7e3d17636b348f005f11040025ae8c6f645fe92"
 uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 version = "0.1.6"
 
-[[FilePathsBase]]
-deps = ["Dates", "Mmap", "Printf", "Test", "UUIDs"]
-git-tree-sha1 = "d962b5a47b6d191dbcd8ae0db841bc70a05a3f5b"
+[[deps.FilePathsBase]]
+deps = ["Compat", "Dates", "Mmap", "Printf", "Test", "UUIDs"]
+git-tree-sha1 = "04d13bfa8ef11720c24e4d840c0033d145537df7"
 uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
-version = "0.9.13"
+version = "0.9.17"
 
-[[FillArrays]]
+[[deps.FillArrays]]
 deps = ["LinearAlgebra", "Random", "SparseArrays", "Statistics"]
 git-tree-sha1 = "8756f9935b7ccc9064c6eef0bff0ad643df733a3"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
 version = "0.12.7"
 
-[[FiniteDiff]]
+[[deps.FiniteDiff]]
 deps = ["ArrayInterface", "LinearAlgebra", "Requires", "SparseArrays", "StaticArrays"]
 git-tree-sha1 = "8b3c09b56acaf3c0e581c66638b85c8650ee9dca"
 uuid = "6a86dc24-6348-571c-b903-95158fe2bd41"
 version = "2.8.1"
 
-[[FixedPointNumbers]]
+[[deps.FixedPointNumbers]]
 deps = ["Statistics"]
 git-tree-sha1 = "335bfdceacc84c5cdf16aadc768aa5ddfc5383cc"
 uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 version = "0.8.4"
 
-[[Formatting]]
+[[deps.Formatting]]
 deps = ["Printf"]
 git-tree-sha1 = "8339d61043228fdd3eb658d86c926cb282ae72a8"
 uuid = "59287772-0a20-5a39-b81b-1366585eb4c0"
 version = "0.4.2"
 
-[[ForwardDiff]]
-deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
-git-tree-sha1 = "63777916efbcb0ab6173d09a658fb7f2783de485"
+[[deps.ForwardDiff]]
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
+git-tree-sha1 = "2b72a5624e289ee18256111657663721d59c143e"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.21"
+version = "0.10.24"
 
-[[Future]]
+[[deps.Future]]
 deps = ["Random"]
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 
-[[GPUArrays]]
+[[deps.GPUArrays]]
 deps = ["Adapt", "LinearAlgebra", "Printf", "Random", "Serialization", "Statistics"]
-git-tree-sha1 = "7772508f17f1d482fe0df72cabc5b55bec06bbe0"
+git-tree-sha1 = "d9681e61fbce7dde48684b40bdb1a319c4083be7"
 uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
-version = "8.1.2"
+version = "8.1.3"
 
-[[GPUCompiler]]
+[[deps.GPUCompiler]]
 deps = ["ExprTools", "InteractiveUtils", "LLVM", "Libdl", "Logging", "TimerOutputs", "UUIDs"]
-git-tree-sha1 = "77d915a0af27d474f0aaf12fcd46c400a552e84c"
+git-tree-sha1 = "2cac236070c2c4b36de54ae9146b55ee2c34ac7a"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
-version = "0.13.7"
+version = "0.13.10"
 
-[[GeometryBasics]]
+[[deps.GeometryBasics]]
 deps = ["EarCut_jll", "IterTools", "LinearAlgebra", "StaticArrays", "StructArrays", "Tables"]
 git-tree-sha1 = "58bcdf5ebc057b085e58d95c138725628dd7453c"
 uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 version = "0.4.1"
 
-[[HTTP]]
+[[deps.HTTP]]
 deps = ["Base64", "Dates", "IniFile", "Logging", "MbedTLS", "NetworkOptions", "Sockets", "URIs"]
-git-tree-sha1 = "14eece7a3308b4d8be910e265c724a6ba51a9798"
+git-tree-sha1 = "0fa77022fe4b511826b39c894c90daf5fce3334a"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.9.16"
+version = "0.9.17"
 
-[[IfElse]]
+[[deps.IfElse]]
 git-tree-sha1 = "debdd00ffef04665ccbb3e150747a77560e8fad1"
 uuid = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
 version = "0.1.1"
 
-[[IniFile]]
+[[deps.IniFile]]
 deps = ["Test"]
 git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
 uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
 version = "0.5.0"
 
-[[InlineStrings]]
+[[deps.InlineStrings]]
 deps = ["Parsers"]
-git-tree-sha1 = "19cb49649f8c41de7fea32d089d37de917b553da"
+git-tree-sha1 = "8d70835a3759cdd75881426fced1508bb7b7e1b6"
 uuid = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
-version = "1.0.1"
+version = "1.1.1"
 
-[[InteractiveUtils]]
+[[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
-[[InverseFunctions]]
+[[deps.InverseFunctions]]
 deps = ["Test"]
-git-tree-sha1 = "f0c6489b12d28fb4c2103073ec7452f3423bd308"
+git-tree-sha1 = "a7254c0acd8e62f1ac75ad24d5db43f5f19f3c65"
 uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
-version = "0.1.1"
+version = "0.1.2"
 
-[[InvertedIndices]]
+[[deps.InvertedIndices]]
 git-tree-sha1 = "bee5f1ef5bf65df56bdd2e40447590b272a5471f"
 uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
 version = "1.1.0"
 
-[[IrrationalConstants]]
+[[deps.IrrationalConstants]]
 git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
 uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
 version = "0.1.1"
 
-[[IterTools]]
-git-tree-sha1 = "05110a2ab1fc5f932622ffea2a003221f4782c18"
+[[deps.IterTools]]
+git-tree-sha1 = "fa6287a4469f5e048d763df38279ee729fbd44e5"
 uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
-version = "1.3.0"
+version = "1.4.0"
 
-[[IterationControl]]
+[[deps.IterationControl]]
 deps = ["EarlyStopping", "InteractiveUtils"]
-git-tree-sha1 = "f61d5d4d0e433b3fab03ca5a1bfa2d7dcbb8094c"
+git-tree-sha1 = "83c84b7b87d3063e48a909a86c3c5bf4c3521962"
 uuid = "b3c1a2ee-3fec-4384-bf48-272ea71de57c"
-version = "0.4.0"
+version = "0.5.2"
 
-[[IterativeSolvers]]
+[[deps.IterativeSolvers]]
 deps = ["LinearAlgebra", "Printf", "Random", "RecipesBase", "SparseArrays"]
-git-tree-sha1 = "1a8c6237e78b714e901e406c096fc8a65528af7d"
+git-tree-sha1 = "1169632f425f79429f245113b775a0e3d121457c"
 uuid = "42fd0dbc-a981-5370-80f2-aaf504508153"
-version = "0.9.1"
+version = "0.9.2"
 
-[[IteratorInterfaceExtensions]]
+[[deps.IteratorInterfaceExtensions]]
 git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
 uuid = "82899510-4779-5014-852e-03e436cf321d"
 version = "1.0.0"
 
-[[JLLWrappers]]
+[[deps.JLLWrappers]]
 deps = ["Preferences"]
 git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.3.0"
 
-[[JLSO]]
+[[deps.JLSO]]
 deps = ["BSON", "CodecZlib", "FilePathsBase", "Memento", "Pkg", "Serialization"]
 git-tree-sha1 = "e00feb9d56e9e8518e0d60eef4d1040b282771e2"
 uuid = "9da8a3cd-07a3-59c0-a743-3fdc52c30d11"
 version = "2.6.0"
 
-[[JSON]]
+[[deps.JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
 git-tree-sha1 = "8076680b162ada2a031f707ac7b4953e30667a37"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.2"
 
-[[LLVM]]
+[[deps.LLVM]]
 deps = ["CEnum", "LLVMExtra_jll", "Libdl", "Printf", "Unicode"]
-git-tree-sha1 = "46092047ca4edc10720ecab437c42283cd7c44f3"
+git-tree-sha1 = "7cc22e69995e2329cc047a879395b2b74647ab5f"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "4.6.0"
+version = "4.7.0"
 
-[[LLVMExtra_jll]]
+[[deps.LLVMExtra_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "6a2af408fe809c4f1a54d2b3f188fdd3698549d6"
+git-tree-sha1 = "c5fc4bef251ecd37685bea1c4068a9cfa41e8b9a"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.11+0"
+version = "0.0.13+0"
 
-[[LatinHypercubeSampling]]
+[[deps.LatinHypercubeSampling]]
 deps = ["Random", "StableRNGs", "StatsBase", "Test"]
 git-tree-sha1 = "42938ab65e9ed3c3029a8d2c58382ca75bdab243"
 uuid = "a5e1c1ea-c99a-51d3-a14d-a9a37257b02d"
 version = "1.8.0"
 
-[[LazyArtifacts]]
+[[deps.LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
 uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 
-[[LearnBase]]
+[[deps.LearnBase]]
 git-tree-sha1 = "a0d90569edd490b82fdc4dc078ea54a5a800d30a"
 uuid = "7f8f8fb0-2700-5f03-b4bd-41f8cfc144b6"
 version = "0.4.1"
 
-[[LibCURL]]
+[[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 
-[[LibCURL_jll]]
+[[deps.LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
 
-[[LibGit2]]
+[[deps.LibGit2]]
 deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
-[[LibSSH2_jll]]
+[[deps.LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 
-[[Libdl]]
+[[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
-[[LineSearches]]
+[[deps.LineSearches]]
 deps = ["LinearAlgebra", "NLSolversBase", "NaNMath", "Parameters", "Printf"]
 git-tree-sha1 = "f27132e551e959b3667d8c93eae90973225032dd"
 uuid = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
 version = "7.1.1"
 
-[[LinearAlgebra]]
-deps = ["Libdl"]
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
-[[LinearMaps]]
+[[deps.LinearMaps]]
 deps = ["LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "ce708e2b5bbab5c47ffc24200566cbdfa04ff1c1"
+git-tree-sha1 = "dbb14c604fc47aa4f2e19d0ebb7b6416f3cfa5f5"
 uuid = "7a12625a-238d-50fd-b39a-03d52299707e"
-version = "3.5.0"
+version = "3.5.1"
 
-[[LogExpFunctions]]
-deps = ["ChainRulesCore", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "6193c3815f13ba1b78a51ce391db8be016ae9214"
+[[deps.LogExpFunctions]]
+deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "e5718a00af0ab9756305a0392832c8952c7426c1"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.4"
+version = "0.3.6"
 
-[[Logging]]
+[[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
-[[LossFunctions]]
+[[deps.LossFunctions]]
 deps = ["InteractiveUtils", "LearnBase", "Markdown", "RecipesBase", "StatsBase"]
 git-tree-sha1 = "0f057f6ea90a84e73a8ef6eebb4dc7b5c330020f"
 uuid = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
 version = "0.7.2"
 
-[[MLJ]]
+[[deps.MLJ]]
 deps = ["CategoricalArrays", "ComputationalResources", "Distributed", "Distributions", "LinearAlgebra", "MLJBase", "MLJEnsembles", "MLJIteration", "MLJModels", "MLJSerialization", "MLJTuning", "OpenML", "Pkg", "ProgressMeter", "Random", "ScientificTypes", "Statistics", "StatsBase", "Tables"]
-git-tree-sha1 = "2a1ed07cdeeb238bc986235b303d3d73e02118f6"
+git-tree-sha1 = "3b4ebc5023cc039c65a1089e6d8c248a9b96dfd1"
 uuid = "add582a8-e3ab-11e8-2d5e-e98b27df1bc7"
-version = "0.16.11"
+version = "0.17.0"
 
-[[MLJBase]]
-deps = ["CategoricalArrays", "ComputationalResources", "Dates", "DelimitedFiles", "Distributed", "Distributions", "InteractiveUtils", "InvertedIndices", "LinearAlgebra", "LossFunctions", "MLJModelInterface", "Missings", "OrderedCollections", "Parameters", "PrettyTables", "ProgressMeter", "Random", "ScientificTypes", "StatisticalTraits", "Statistics", "StatsBase", "Tables"]
-git-tree-sha1 = "fb9e0429525ccbb0fb4528bff2dc3cdba1feab53"
+[[deps.MLJBase]]
+deps = ["CategoricalArrays", "CategoricalDistributions", "ComputationalResources", "Dates", "DelimitedFiles", "Distributed", "Distributions", "InteractiveUtils", "InvertedIndices", "LinearAlgebra", "LossFunctions", "MLJModelInterface", "Missings", "OrderedCollections", "Parameters", "PrettyTables", "ProgressMeter", "Random", "ScientificTypes", "StatisticalTraits", "Statistics", "StatsBase", "Tables"]
+git-tree-sha1 = "54cae1f0bde7bbc72fe7ff42353b7880347bd0d5"
 uuid = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
-version = "0.18.24"
+version = "0.19.2"
 
-[[MLJEnsembles]]
-deps = ["CategoricalArrays", "ComputationalResources", "Distributed", "Distributions", "MLJBase", "MLJModelInterface", "ProgressMeter", "Random", "ScientificTypes", "StatsBase"]
-git-tree-sha1 = "f8ca949d52432b81f621d9da641cf59829ad2c8c"
+[[deps.MLJEnsembles]]
+deps = ["CategoricalArrays", "CategoricalDistributions", "ComputationalResources", "Distributed", "Distributions", "MLJBase", "MLJModelInterface", "ProgressMeter", "Random", "ScientificTypesBase", "StatsBase"]
+git-tree-sha1 = "4279437ccc8ece8f478ded5139334b888dcce631"
 uuid = "50ed68f4-41fd-4504-931a-ed422449fee0"
-version = "0.1.2"
+version = "0.2.0"
 
-[[MLJIteration]]
+[[deps.MLJIteration]]
 deps = ["IterationControl", "MLJBase", "Random"]
-git-tree-sha1 = "1c94830f8927b10a5653d6e1868c20faccf57be5"
+git-tree-sha1 = "5f32c3d281904d6e5fc64250f55732d4b24014de"
 uuid = "614be32b-d00c-4edb-bd02-1eb411ab5e55"
-version = "0.3.3"
+version = "0.4.1"
 
-[[MLJLinearModels]]
+[[deps.MLJLinearModels]]
 deps = ["DocStringExtensions", "IterativeSolvers", "LinearAlgebra", "LinearMaps", "MLJModelInterface", "Optim", "Parameters"]
-git-tree-sha1 = "9eb4f07f23d44a898213eb4927869598442d90bb"
+git-tree-sha1 = "dfbf4a5a8454034d21b6cfd9fd5a7960c8f7fb88"
 uuid = "6ee0df7b-362f-4a72-a706-9e79364fb692"
-version = "0.5.6"
+version = "0.5.7"
 
-[[MLJModelInterface]]
+[[deps.MLJModelInterface]]
 deps = ["Random", "ScientificTypesBase", "StatisticalTraits"]
-git-tree-sha1 = "0174e9d180b0cae1f8fe7976350ad52f0e70e0d8"
+git-tree-sha1 = "7ffdd75b2b13d1ec8640bfe80ab81bb158910a1d"
 uuid = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
-version = "1.3.3"
+version = "1.3.5"
 
-[[MLJModels]]
-deps = ["CategoricalArrays", "Dates", "Distances", "Distributions", "InteractiveUtils", "LinearAlgebra", "MLJBase", "MLJModelInterface", "OrderedCollections", "Parameters", "Pkg", "REPL", "Random", "Requires", "ScientificTypes", "Statistics", "StatsBase", "Tables"]
-git-tree-sha1 = "25dfbfa33d1e7dabcdec63e00585974f85715851"
+[[deps.MLJModels]]
+deps = ["CategoricalArrays", "CategoricalDistributions", "Dates", "Distances", "Distributions", "InteractiveUtils", "LinearAlgebra", "MLJModelInterface", "OrderedCollections", "Parameters", "Pkg", "PrettyPrinting", "REPL", "Random", "Requires", "ScientificTypes", "StatisticalTraits", "Statistics", "StatsBase", "Tables"]
+git-tree-sha1 = "cecd98731368f1eb46634d1476f49332560f886f"
 uuid = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
-version = "0.14.12"
+version = "0.15.1"
 
-[[MLJMultivariateStatsInterface]]
+[[deps.MLJMultivariateStatsInterface]]
 deps = ["Distances", "LinearAlgebra", "MLJModelInterface", "MultivariateStats", "StatsBase"]
 git-tree-sha1 = "0cfc81ff677ea13ed72894992ee9e5f8ae4dbb9d"
 uuid = "1b6a4a23-ba22-4f51-9698-8599985d3728"
 version = "0.2.2"
 
-[[MLJSerialization]]
+[[deps.MLJSerialization]]
 deps = ["IterationControl", "JLSO", "MLJBase", "MLJModelInterface"]
-git-tree-sha1 = "cd6285f95948fe1047b7d6fd346c172e247c1188"
+git-tree-sha1 = "cc5877ad02ef02e273d2622f0d259d628fa61cd0"
 uuid = "17bed46d-0ab5-4cd4-b792-a5c4b8547c6d"
-version = "1.1.2"
+version = "1.1.3"
 
-[[MLJTuning]]
+[[deps.MLJTuning]]
 deps = ["ComputationalResources", "Distributed", "Distributions", "LatinHypercubeSampling", "MLJBase", "ProgressMeter", "Random", "RecipesBase"]
-git-tree-sha1 = "8f3911fa3aef4299059f573cf75669d61f8bcef5"
+git-tree-sha1 = "a443cc088158b949876d7038a1aa37cfc8c5509b"
 uuid = "03970b2e-30c4-11ea-3135-d1576263f10f"
-version = "0.6.14"
+version = "0.6.16"
 
-[[MacroTools]]
+[[deps.MacroTools]]
 deps = ["Markdown", "Random"]
 git-tree-sha1 = "3d3e902b31198a27340d0bf00d6ac452866021cf"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 version = "0.5.9"
 
-[[Markdown]]
+[[deps.Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
-[[MbedTLS]]
+[[deps.MbedTLS]]
 deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
 git-tree-sha1 = "1c38e51c3d08ef2278062ebceade0e46cefc96fe"
 uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
 version = "1.0.3"
 
-[[MbedTLS_jll]]
+[[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 
-[[Memento]]
-deps = ["Dates", "Distributed", "JSON", "Serialization", "Sockets", "Syslogs", "Test", "TimeZones", "UUIDs"]
-git-tree-sha1 = "19650888f97362a2ae6c84f0f5f6cda84c30ac38"
+[[deps.Memento]]
+deps = ["Dates", "Distributed", "Requires", "Serialization", "Sockets", "Test", "UUIDs"]
+git-tree-sha1 = "9b0b0dbf419fbda7b383dc12d108621d26eeb89f"
 uuid = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
-version = "1.2.0"
+version = "1.3.0"
 
-[[Missings]]
+[[deps.Missings]]
 deps = ["DataAPI"]
 git-tree-sha1 = "bf210ce90b6c9eed32d25dbcae1ebc565df2687f"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 version = "1.0.2"
 
-[[Mmap]]
+[[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
-[[Mocking]]
-deps = ["Compat", "ExprTools"]
-git-tree-sha1 = "29714d0a7a8083bba8427a4fbfb00a540c681ce7"
-uuid = "78c3b35d-d492-501b-9361-3d52fe80e533"
-version = "0.7.3"
-
-[[MozillaCACerts_jll]]
+[[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 
-[[MultivariateStats]]
+[[deps.MultivariateStats]]
 deps = ["Arpack", "LinearAlgebra", "SparseArrays", "Statistics", "StatsBase"]
 git-tree-sha1 = "8d958ff1854b166003238fe191ec34b9d592860a"
 uuid = "6f286f6a-111f-5878-ab1e-185364afe411"
 version = "0.8.0"
 
-[[NLSolversBase]]
+[[deps.NLSolversBase]]
 deps = ["DiffResults", "Distributed", "FiniteDiff", "ForwardDiff"]
-git-tree-sha1 = "144bab5b1443545bc4e791536c9f1eacb4eed06a"
+git-tree-sha1 = "50310f934e55e5ca3912fb941dec199b49ca9b68"
 uuid = "d41bc354-129a-5804-8e4c-c37616107c6c"
-version = "7.8.1"
+version = "7.8.2"
 
-[[NaNMath]]
-git-tree-sha1 = "bfe47e760d60b82b66b61d2d44128b62e3a369fb"
+[[deps.NaNMath]]
+git-tree-sha1 = "f755f36b19a5116bb580de457cda0c140153f283"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
-version = "0.3.5"
+version = "0.3.6"
 
-[[NetworkLayout]]
+[[deps.NetworkLayout]]
 deps = ["GeometryBasics", "LinearAlgebra", "Random", "Requires", "SparseArrays"]
 git-tree-sha1 = "24e10982e84dd35cd867102243454bf8a4581a76"
 uuid = "46757867-2c16-5918-afeb-47bfcb05e46a"
 version = "0.4.3"
 
-[[NetworkOptions]]
+[[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 
-[[OpenBLAS_jll]]
+[[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
 
-[[OpenLibm_jll]]
+[[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
 
-[[OpenML]]
-deps = ["ARFFFiles", "HTTP", "JSON", "Markdown", "Pkg", "ScientificTypes"]
-git-tree-sha1 = "79ffa09cf7c730b36342699553feef3e1f169ec6"
+[[deps.OpenML]]
+deps = ["ARFFFiles", "HTTP", "JSON", "Markdown", "Pkg"]
+git-tree-sha1 = "06080992e86a93957bfe2e12d3181443cedf2400"
 uuid = "8b6db2d4-7670-4922-a472-f9537c81ab66"
-version = "0.1.1"
+version = "0.2.0"
 
-[[OpenSpecFun_jll]]
+[[deps.OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "13652491f6856acfd2db29360e1bbcd4565d04f1"
 uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 version = "0.5.5+0"
 
-[[Optim]]
-deps = ["Compat", "FillArrays", "LineSearches", "LinearAlgebra", "NLSolversBase", "NaNMath", "Parameters", "PositiveFactorizations", "Printf", "SparseArrays", "StatsBase"]
-git-tree-sha1 = "7863df65dbb2a0fa8f85fcaf0a41167640d2ebed"
+[[deps.Optim]]
+deps = ["Compat", "FillArrays", "ForwardDiff", "LineSearches", "LinearAlgebra", "NLSolversBase", "NaNMath", "Parameters", "PositiveFactorizations", "Printf", "SparseArrays", "StatsBase"]
+git-tree-sha1 = "916077e0f0f8966eb0dc98a5c39921fdb8f49eb4"
 uuid = "429524aa-4258-5aef-a3af-852621145aeb"
-version = "1.4.1"
+version = "1.6.0"
 
-[[OrderedCollections]]
+[[deps.OrderedCollections]]
 git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.4.1"
 
-[[PDMats]]
+[[deps.PDMats]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "82041e63725d156bf61c6302dd7635ea13e3d5e7"
+git-tree-sha1 = "ee26b350276c51697c9c2d88a072b339f9f03d73"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.2"
+version = "0.11.5"
 
-[[Parameters]]
+[[deps.Parameters]]
 deps = ["OrderedCollections", "UnPack"]
 git-tree-sha1 = "34c0e9ad262e5f7fc75b10a9952ca7692cfc5fbe"
 uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 version = "0.12.3"
 
-[[Parsers]]
+[[deps.Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "d911b6a12ba974dabe2291c6d450094a7226b372"
+git-tree-sha1 = "d7fa6237da8004be601e19bd6666083056649918"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.1.1"
+version = "2.1.3"
 
-[[Pkg]]
+[[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
-[[PooledArrays]]
+[[deps.PooledArrays]]
 deps = ["DataAPI", "Future"]
-git-tree-sha1 = "a193d6ad9c45ada72c14b731a318bedd3c2f00cf"
+git-tree-sha1 = "db3a23166af8aebf4db5ef87ac5b00d36eb771e2"
 uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
-version = "1.3.0"
+version = "1.4.0"
 
-[[PositiveFactorizations]]
+[[deps.PositiveFactorizations]]
 deps = ["LinearAlgebra"]
 git-tree-sha1 = "17275485f373e6673f7e7f97051f703ed5b15b20"
 uuid = "85a6dd25-e78a-55b7-8502-1745935b8125"
 version = "0.2.4"
 
-[[Preferences]]
+[[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "00cfd92944ca9c760982747e9a1d0d5d86ab1e5a"
+git-tree-sha1 = "2cf929d64681236a2e074ffafb8d568733d2e6af"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.2.2"
-
-[[PrettyTables]]
-deps = ["Crayons", "Formatting", "Markdown", "Reexport", "Tables"]
-git-tree-sha1 = "d940010be611ee9d67064fe559edbb305f8cc0eb"
-uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 version = "1.2.3"
 
-[[Printf]]
+[[deps.PrettyPrinting]]
+git-tree-sha1 = "a5db8a42938bc65c2679406c51a8f5fe9597c6e7"
+uuid = "54e16d92-306c-5ea0-a30b-337be88ac337"
+version = "0.3.2"
+
+[[deps.PrettyTables]]
+deps = ["Crayons", "Formatting", "Markdown", "Reexport", "Tables"]
+git-tree-sha1 = "dfb54c4e414caa595a1f2ed759b160f5a3ddcba5"
+uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+version = "1.3.1"
+
+[[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
-[[ProgressMeter]]
+[[deps.ProgressMeter]]
 deps = ["Distributed", "Printf"]
 git-tree-sha1 = "afadeba63d90ff223a6a48d2009434ecee2ec9e8"
 uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
 version = "1.7.1"
 
-[[QuadGK]]
+[[deps.QuadGK]]
 deps = ["DataStructures", "LinearAlgebra"]
 git-tree-sha1 = "78aadffb3efd2155af139781b8a8df1ef279ea39"
 uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 version = "2.4.2"
 
-[[REPL]]
+[[deps.REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
-[[Random]]
-deps = ["Serialization"]
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
-[[Random123]]
+[[deps.Random123]]
 deps = ["Libdl", "Random", "RandomNumbers"]
 git-tree-sha1 = "0e8b146557ad1c6deb1367655e052276690e71a3"
 uuid = "74087812-796a-5b5d-8853-05524746bad3"
 version = "1.4.2"
 
-[[RandomNumbers]]
+[[deps.RandomNumbers]]
 deps = ["Random", "Requires"]
 git-tree-sha1 = "043da614cc7e95c703498a491e2c21f58a2b8111"
 uuid = "e6cf234a-135c-5ec9-84dd-332b85af5143"
 version = "1.5.3"
 
-[[RecipesBase]]
-git-tree-sha1 = "44a75aa7a527910ee3d1751d1f0e4148698add9e"
+[[deps.RecipesBase]]
+git-tree-sha1 = "6bf3f380ff52ce0832ddd3a2a7b9538ed1bcca7d"
 uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-version = "1.1.2"
+version = "1.2.1"
 
-[[Reexport]]
+[[deps.Reexport]]
 git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 version = "1.2.2"
 
-[[Requires]]
+[[deps.Requires]]
 deps = ["UUIDs"]
-git-tree-sha1 = "4036a3bd08ac7e968e27c203d45f5fff15020621"
+git-tree-sha1 = "8f82019e525f4d5c669692772a6f4b0a58b06a6a"
 uuid = "ae029012-a4dd-5104-9daa-d747884805df"
-version = "1.1.3"
+version = "1.2.0"
 
-[[Rmath]]
+[[deps.Rmath]]
 deps = ["Random", "Rmath_jll"]
 git-tree-sha1 = "bf3188feca147ce108c76ad82c2792c57abe7b1f"
 uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
 version = "0.7.0"
 
-[[Rmath_jll]]
+[[deps.Rmath_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "68db32dff12bb6127bac73c209881191bf0efbb7"
 uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
 version = "0.3.0+0"
 
-[[SHA]]
+[[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
-[[ScientificTypes]]
+[[deps.ScientificTypes]]
 deps = ["CategoricalArrays", "ColorTypes", "Dates", "Distributions", "PrettyTables", "Reexport", "ScientificTypesBase", "StatisticalTraits", "Tables"]
-git-tree-sha1 = "7a3efcacd212801a8cf2f961e8238ffb2109b30d"
+git-tree-sha1 = "ba70c9a6e4c81cc3634e3e80bb8163ab5ef57eb8"
 uuid = "321657f4-b219-11e9-178b-2701a2544e81"
-version = "2.3.3"
+version = "3.0.0"
 
-[[ScientificTypesBase]]
-git-tree-sha1 = "185e373beaf6b381c1e7151ce2c2a722351d6637"
+[[deps.ScientificTypesBase]]
+git-tree-sha1 = "a8e18eb383b5ecf1b5e6fc237eb39255044fd92b"
 uuid = "30f210dd-8aff-4c5f-94ba-8e64358c1161"
-version = "2.3.0"
+version = "3.0.0"
 
-[[SentinelArrays]]
+[[deps.SentinelArrays]]
 deps = ["Dates", "Random"]
-git-tree-sha1 = "f45b34656397a1f6e729901dc9ef679610bd12b5"
+git-tree-sha1 = "244586bc07462d22aed0113af9c731f2a518c93e"
 uuid = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
-version = "1.3.8"
+version = "1.3.10"
 
-[[Serialization]]
+[[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
-[[SharedArrays]]
+[[deps.SharedArrays]]
 deps = ["Distributed", "Mmap", "Random", "Serialization"]
 uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 
-[[Sockets]]
+[[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
-[[SortingAlgorithms]]
+[[deps.SortingAlgorithms]]
 deps = ["DataStructures"]
 git-tree-sha1 = "b3363d7460f7d098ca0912c69b082f75625d7508"
 uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
 version = "1.0.1"
 
-[[SparseArrays]]
+[[deps.SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
-[[SpecialFunctions]]
+[[deps.SpecialFunctions]]
 deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
-git-tree-sha1 = "f0bccf98e16759818ffc5d97ac3ebf87eb950150"
+git-tree-sha1 = "e08890d19787ec25029113e88c34ec20cac1c91e"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.8.1"
+version = "2.0.0"
 
-[[StableRNGs]]
+[[deps.StableRNGs]]
 deps = ["Random", "Test"]
 git-tree-sha1 = "3be7d49667040add7ee151fefaf1f8c04c8c8276"
 uuid = "860ef19b-820b-49d6-a774-d7a799459cd3"
 version = "1.0.0"
 
-[[Static]]
+[[deps.Static]]
 deps = ["IfElse"]
-git-tree-sha1 = "e7bc80dc93f50857a5d1e3c8121495852f407e6a"
+git-tree-sha1 = "7f5a513baec6f122401abfc8e9c074fdac54f6c1"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-version = "0.4.0"
+version = "0.4.1"
 
-[[StaticArrays]]
+[[deps.StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "3c76dde64d03699e074ac02eb2e8ba8254d428da"
+git-tree-sha1 = "de9e88179b584ba9cf3cc5edbb7a41f26ce42cda"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.2.13"
+version = "1.3.0"
 
-[[StatisticalTraits]]
+[[deps.StatisticalTraits]]
 deps = ["ScientificTypesBase"]
-git-tree-sha1 = "730732cae4d3135e2f2182bd47f8d8b795ea4439"
+git-tree-sha1 = "271a7fea12d319f23d55b785c51f6876aadb9ac0"
 uuid = "64bff920-2084-43da-a3e6-9bb72801c0c9"
-version = "2.1.0"
+version = "3.0.0"
 
-[[Statistics]]
+[[deps.Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
-[[StatsAPI]]
-git-tree-sha1 = "1958272568dc176a1d881acb797beb909c785510"
+[[deps.StatsAPI]]
+git-tree-sha1 = "d88665adc9bcf45903013af0982e2fd05ae3d0a6"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
-version = "1.0.0"
+version = "1.2.0"
 
-[[StatsBase]]
+[[deps.StatsBase]]
 deps = ["DataAPI", "DataStructures", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
-git-tree-sha1 = "eb35dcc66558b2dda84079b9a1be17557d32091a"
+git-tree-sha1 = "51383f2d367eb3b444c961d485c565e4c0cf4ba0"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.33.12"
+version = "0.33.14"
 
-[[StatsFuns]]
-deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
-git-tree-sha1 = "95072ef1a22b057b1e80f73c2a89ad238ae4cfff"
+[[deps.StatsFuns]]
+deps = ["ChainRulesCore", "InverseFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
+git-tree-sha1 = "bedb3e17cc1d94ce0e6e66d3afa47157978ba404"
 uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
-version = "0.9.12"
+version = "0.9.14"
 
-[[StructArrays]]
+[[deps.StructArrays]]
 deps = ["Adapt", "DataAPI", "StaticArrays", "Tables"]
 git-tree-sha1 = "2ce41e0d042c60ecd131e9fb7154a3bfadbf50d3"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 version = "0.6.3"
 
-[[SuiteSparse]]
+[[deps.SuiteSparse]]
 deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
 uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
-[[Syslogs]]
-deps = ["Printf", "Sockets"]
-git-tree-sha1 = "46badfcc7c6e74535cc7d833a91f4ac4f805f86d"
-uuid = "cea106d9-e007-5e6c-ad93-58fe2094e9c4"
-version = "0.3.0"
-
-[[TOML]]
+[[deps.TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
-[[TableTraits]]
+[[deps.TableTraits]]
 deps = ["IteratorInterfaceExtensions"]
 git-tree-sha1 = "c06b2f539df1c6efa794486abfb6ed2022561a39"
 uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
 version = "1.0.1"
 
-[[Tables]]
+[[deps.Tables]]
 deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
-git-tree-sha1 = "fed34d0e71b91734bf0a7e10eb1bb05296ddbcd0"
+git-tree-sha1 = "bb1064c9a84c52e277f1096cf41434b675cd368b"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "1.6.0"
+version = "1.6.1"
 
-[[Tar]]
+[[deps.Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 
-[[Test]]
+[[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[[TimeZones]]
-deps = ["Dates", "Downloads", "InlineStrings", "LazyArtifacts", "Mocking", "Pkg", "Printf", "RecipesBase", "Serialization", "Unicode"]
-git-tree-sha1 = "8de32288505b7db196f36d27d7236464ef50dba1"
-uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
-version = "1.6.2"
-
-[[TimerOutputs]]
+[[deps.TimerOutputs]]
 deps = ["ExprTools", "Printf"]
 git-tree-sha1 = "7cb456f358e8f9d102a8b25e8dfedf58fa5689bc"
 uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 version = "0.5.13"
 
-[[TranscodingStreams]]
+[[deps.TranscodingStreams]]
 deps = ["Random", "Test"]
 git-tree-sha1 = "216b95ea110b5972db65aa90f88d8d89dcb8851c"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 version = "0.9.6"
 
-[[URIs]]
+[[deps.URIs]]
 git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 version = "1.3.0"
 
-[[UUIDs]]
+[[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
-[[UnPack]]
+[[deps.UnPack]]
 git-tree-sha1 = "387c1f73762231e86e0c9c5443ce3b4a0a9a0c2b"
 uuid = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 version = "1.0.2"
 
-[[Unicode]]
+[[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
-[[UrlDownload]]
+[[deps.UnicodePlots]]
+deps = ["Crayons", "Dates", "SparseArrays", "StatsBase"]
+git-tree-sha1 = "3cb994143aba28cfe66615702505b2d294cebd3e"
+uuid = "b8865327-cd53-5732-bb35-84acbb429228"
+version = "2.5.1"
+
+[[deps.UrlDownload]]
 deps = ["HTTP", "ProgressMeter"]
 git-tree-sha1 = "05f86730c7a53c9da603bd506a4fc9ad0851171c"
 uuid = "856ac37a-3032-4c1c-9122-f86d88358c8b"
 version = "1.0.0"
 
-[[WeakRefStrings]]
+[[deps.WeakRefStrings]]
 deps = ["DataAPI", "InlineStrings", "Parsers"]
 git-tree-sha1 = "c69f9da3ff2f4f02e811c3323c22e5dfcb584cfa"
 uuid = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 version = "1.4.1"
 
-[[Zlib_jll]]
+[[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
 
-[[nghttp2_jll]]
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+
+[[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
 
-[[p7zip_jll]]
+[[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/notebooks/03_pipelines/env/Project.toml
+++ b/notebooks/03_pipelines/env/Project.toml
@@ -6,3 +6,6 @@ MLJ = "add582a8-e3ab-11e8-2d5e-e98b27df1bc7"
 MLJLinearModels = "6ee0df7b-362f-4a72-a706-9e79364fb692"
 MLJMultivariateStatsInterface = "1b6a4a23-ba22-4f51-9698-8599985d3728"
 UrlDownload = "856ac37a-3032-4c1c-9122-f86d88358c8b"
+
+[compat]
+julia = "1.6"

--- a/notebooks/03_pipelines/env/generate.jl
+++ b/notebooks/03_pipelines/env/generate.jl
@@ -2,4 +2,4 @@
 
 env = @__DIR__
 joinpath(env, "..", "..", "..", "generate.jl") |> include
-generate(env, execute=false)
+generate(env)

--- a/notebooks/03_pipelines/notebook.ipynb
+++ b/notebooks/03_pipelines/notebook.ipynb
@@ -35,7 +35,7 @@
     {
      "output_type": "execute_result",
      "data": {
-      "text/plain": "v\"1.7.1\""
+      "text/plain": "v\"1.6.5\""
      },
      "metadata": {},
      "execution_count": 1
@@ -58,7 +58,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "The package environment has been created using **Julia 1.7** and may not\n",
+    "The package environment has been created using **Julia 1.6** and may not\n",
     "instantiate properly for other Julia versions."
    ],
    "metadata": {}
@@ -69,7 +69,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Activating project at `~/GoogleDrive/Julia/MLJ/MLJTutorial/notebooks/03_pipelines/env`\n"
+      "  Activating environment at `~/GoogleDrive/Julia/MLJ/MLJTutorial/notebooks/03_pipelines/env/Project.toml`\n"
      ]
     }
    ],
@@ -138,8 +138,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "mean(x) = 0.48986440325190694\n",
-      "std(x) = 0.2875350590235868\n"
+      "mean(x) = 0.5191343981096598\n",
+      "std(x) = 0.29775348216275793\n"
      ]
     }
    ],
@@ -160,8 +160,8 @@
      "output_type": "stream",
      "text": [
       "[ Info: Training Machine{Standardizer,…}.\n",
-      "mean(xhat) = -4.551914400963141e-16\n",
-      "std(xhat) = 0.9999999999999999\n"
+      "mean(xhat) = 9.128114930589958e-17\n",
+      "std(xhat) = 1.0\n"
      ]
     }
    ],
@@ -365,7 +365,7 @@
     {
      "output_type": "execute_result",
      "data": {
-      "text/plain": "60-element Vector{NamedTuple{(:name, :package_name, :is_supervised, :abstract_type, :deep_properties, :docstring, :fit_data_scitype, :hyperparameter_ranges, :hyperparameter_types, :hyperparameters, :implemented_methods, :inverse_transform_scitype, :is_pure_julia, :is_wrapper, :iteration_parameter, :load_path, :package_license, :package_url, :package_uuid, :predict_scitype, :prediction_type, :supports_class_weights, :supports_online, :supports_training_losses, :supports_weights, :transform_scitype, :input_scitype, :target_scitype, :output_scitype)}}:\n (name = ABODDetector, package_name = OutlierDetectionNeighbors, ... )\n (name = ABODDetector, package_name = OutlierDetectionPython, ... )\n (name = AEDetector, package_name = OutlierDetectionNetworks, ... )\n (name = AffinityPropagation, package_name = ScikitLearn, ... )\n (name = AgglomerativeClustering, package_name = ScikitLearn, ... )\n (name = BM25Transformer, package_name = MLJText, ... )\n (name = BagOfWordsTransformer, package_name = MLJText, ... )\n (name = Birch, package_name = ScikitLearn, ... )\n (name = CBLOFDetector, package_name = OutlierDetectionPython, ... )\n (name = COFDetector, package_name = OutlierDetectionNeighbors, ... )\n ⋮\n (name = SpectralClustering, package_name = ScikitLearn, ... )\n (name = Standardizer, package_name = MLJModels, ... )\n (name = TSVDTransformer, package_name = TSVD, ... )\n (name = TfidfTransformer, package_name = MLJText, ... )\n (name = UnivariateBoxCoxTransformer, package_name = MLJModels, ... )\n (name = UnivariateDiscretizer, package_name = MLJModels, ... )\n (name = UnivariateFillImputer, package_name = MLJModels, ... )\n (name = UnivariateStandardizer, package_name = MLJModels, ... )\n (name = UnivariateTimeTypeToContinuous, package_name = MLJModels, ... )"
+      "text/plain": "60-element Vector{NamedTuple{(:name, :package_name, :is_supervised, :abstract_type, :deep_properties, :docstring, :fit_data_scitype, :hyperparameter_ranges, :hyperparameter_types, :hyperparameters, :implemented_methods, :inverse_transform_scitype, :is_pure_julia, :is_wrapper, :iteration_parameter, :load_path, :package_license, :package_url, :package_uuid, :predict_scitype, :prediction_type, :supports_class_weights, :supports_online, :supports_training_losses, :supports_weights, :transform_scitype, :input_scitype, :target_scitype, :output_scitype), T} where T<:Tuple}:\n (name = ABODDetector, package_name = OutlierDetectionNeighbors, ... )\n (name = ABODDetector, package_name = OutlierDetectionPython, ... )\n (name = AEDetector, package_name = OutlierDetectionNetworks, ... )\n (name = AffinityPropagation, package_name = ScikitLearn, ... )\n (name = AgglomerativeClustering, package_name = ScikitLearn, ... )\n (name = BM25Transformer, package_name = MLJText, ... )\n (name = BagOfWordsTransformer, package_name = MLJText, ... )\n (name = Birch, package_name = ScikitLearn, ... )\n (name = CBLOFDetector, package_name = OutlierDetectionPython, ... )\n (name = COFDetector, package_name = OutlierDetectionNeighbors, ... )\n ⋮\n (name = SpectralClustering, package_name = ScikitLearn, ... )\n (name = Standardizer, package_name = MLJModels, ... )\n (name = TSVDTransformer, package_name = TSVD, ... )\n (name = TfidfTransformer, package_name = MLJText, ... )\n (name = UnivariateBoxCoxTransformer, package_name = MLJModels, ... )\n (name = UnivariateDiscretizer, package_name = MLJModels, ... )\n (name = UnivariateFillImputer, package_name = MLJModels, ... )\n (name = UnivariateStandardizer, package_name = MLJModels, ... )\n (name = UnivariateTimeTypeToContinuous, package_name = MLJModels, ... )"
      },
      "metadata": {},
      "execution_count": 11
@@ -669,7 +669,7 @@
     {
      "output_type": "execute_result",
      "data": {
-      "text/plain": "Machine{DeterministicPipeline{NamedTuple{,…},…},…} trained 2 times; caches data\n  model: MLJBase.DeterministicPipeline{NamedTuple{(:continuous_encoder, :pca, :ridge_regressor), Tuple{MLJModelInterface.Unsupervised, MLJModelInterface.Unsupervised, MLJModelInterface.Deterministic}}, MLJModelInterface.predict}\n  args: \n    1:\tSource @697 ⏎ `ScientificTypesBase.Table{Union{AbstractVector{ScientificTypesBase.Continuous}, AbstractVector{ScientificTypesBase.Multiclass{70}}, AbstractVector{ScientificTypesBase.OrderedFactor{6}}, AbstractVector{ScientificTypesBase.OrderedFactor{13}}, AbstractVector{ScientificTypesBase.OrderedFactor{30}}, AbstractVector{ScientificTypesBase.OrderedFactor{5}}, AbstractVector{ScientificTypesBase.OrderedFactor{12}}, AbstractVector{ScientificTypesBase.OrderedFactor{2}}}}`\n    2:\tSource @379 ⏎ `AbstractVector{ScientificTypesBase.Continuous}`\n"
+      "text/plain": "Machine{DeterministicPipeline{NamedTuple{,…},…},…} trained 2 times; caches data\n  model: MLJBase.DeterministicPipeline{NamedTuple{(:continuous_encoder, :pca, :ridge_regressor), Tuple{MLJModelInterface.Unsupervised, MLJModelInterface.Unsupervised, MLJModelInterface.Deterministic}}, MLJModelInterface.predict}\n  args: \n    1:\tSource @516 ⏎ `ScientificTypesBase.Table{Union{AbstractVector{ScientificTypesBase.Continuous}, AbstractVector{ScientificTypesBase.Multiclass{70}}, AbstractVector{ScientificTypesBase.OrderedFactor{6}}, AbstractVector{ScientificTypesBase.OrderedFactor{13}}, AbstractVector{ScientificTypesBase.OrderedFactor{30}}, AbstractVector{ScientificTypesBase.OrderedFactor{5}}, AbstractVector{ScientificTypesBase.OrderedFactor{12}}, AbstractVector{ScientificTypesBase.OrderedFactor{2}}}}`\n    2:\tSource @259 ⏎ `AbstractVector{ScientificTypesBase.Continuous}`\n"
      },
      "metadata": {},
      "execution_count": 19
@@ -697,7 +697,7 @@
     {
      "output_type": "execute_result",
      "data": {
-      "text/plain": "Machine{DeterministicPipeline{NamedTuple{,…},…},…} trained 3 times; caches data\n  model: MLJBase.DeterministicPipeline{NamedTuple{(:continuous_encoder, :pca, :ridge_regressor), Tuple{MLJModelInterface.Unsupervised, MLJModelInterface.Unsupervised, MLJModelInterface.Deterministic}}, MLJModelInterface.predict}\n  args: \n    1:\tSource @697 ⏎ `ScientificTypesBase.Table{Union{AbstractVector{ScientificTypesBase.Continuous}, AbstractVector{ScientificTypesBase.Multiclass{70}}, AbstractVector{ScientificTypesBase.OrderedFactor{6}}, AbstractVector{ScientificTypesBase.OrderedFactor{13}}, AbstractVector{ScientificTypesBase.OrderedFactor{30}}, AbstractVector{ScientificTypesBase.OrderedFactor{5}}, AbstractVector{ScientificTypesBase.OrderedFactor{12}}, AbstractVector{ScientificTypesBase.OrderedFactor{2}}}}`\n    2:\tSource @379 ⏎ `AbstractVector{ScientificTypesBase.Continuous}`\n"
+      "text/plain": "Machine{DeterministicPipeline{NamedTuple{,…},…},…} trained 3 times; caches data\n  model: MLJBase.DeterministicPipeline{NamedTuple{(:continuous_encoder, :pca, :ridge_regressor), Tuple{MLJModelInterface.Unsupervised, MLJModelInterface.Unsupervised, MLJModelInterface.Deterministic}}, MLJModelInterface.predict}\n  args: \n    1:\tSource @516 ⏎ `ScientificTypesBase.Table{Union{AbstractVector{ScientificTypesBase.Continuous}, AbstractVector{ScientificTypesBase.Multiclass{70}}, AbstractVector{ScientificTypesBase.OrderedFactor{6}}, AbstractVector{ScientificTypesBase.OrderedFactor{13}}, AbstractVector{ScientificTypesBase.OrderedFactor{30}}, AbstractVector{ScientificTypesBase.OrderedFactor{5}}, AbstractVector{ScientificTypesBase.OrderedFactor{12}}, AbstractVector{ScientificTypesBase.OrderedFactor{2}}}}`\n    2:\tSource @259 ⏎ `AbstractVector{ScientificTypesBase.Continuous}`\n"
      },
      "metadata": {},
      "execution_count": 20
@@ -741,7 +741,7 @@
     {
      "output_type": "execute_result",
      "data": {
-      "text/plain": "Machine{DeterministicPipeline{NamedTuple{,…},…},…} trained 4 times; caches data\n  model: MLJBase.DeterministicPipeline{NamedTuple{(:continuous_encoder, :pca, :ridge_regressor), Tuple{MLJModelInterface.Unsupervised, MLJModelInterface.Unsupervised, MLJModelInterface.Deterministic}}, MLJModelInterface.predict}\n  args: \n    1:\tSource @697 ⏎ `ScientificTypesBase.Table{Union{AbstractVector{ScientificTypesBase.Continuous}, AbstractVector{ScientificTypesBase.Multiclass{70}}, AbstractVector{ScientificTypesBase.OrderedFactor{6}}, AbstractVector{ScientificTypesBase.OrderedFactor{13}}, AbstractVector{ScientificTypesBase.OrderedFactor{30}}, AbstractVector{ScientificTypesBase.OrderedFactor{5}}, AbstractVector{ScientificTypesBase.OrderedFactor{12}}, AbstractVector{ScientificTypesBase.OrderedFactor{2}}}}`\n    2:\tSource @379 ⏎ `AbstractVector{ScientificTypesBase.Continuous}`\n"
+      "text/plain": "Machine{DeterministicPipeline{NamedTuple{,…},…},…} trained 4 times; caches data\n  model: MLJBase.DeterministicPipeline{NamedTuple{(:continuous_encoder, :pca, :ridge_regressor), Tuple{MLJModelInterface.Unsupervised, MLJModelInterface.Unsupervised, MLJModelInterface.Deterministic}}, MLJModelInterface.predict}\n  args: \n    1:\tSource @516 ⏎ `ScientificTypesBase.Table{Union{AbstractVector{ScientificTypesBase.Continuous}, AbstractVector{ScientificTypesBase.Multiclass{70}}, AbstractVector{ScientificTypesBase.OrderedFactor{6}}, AbstractVector{ScientificTypesBase.OrderedFactor{13}}, AbstractVector{ScientificTypesBase.OrderedFactor{30}}, AbstractVector{ScientificTypesBase.OrderedFactor{5}}, AbstractVector{ScientificTypesBase.OrderedFactor{12}}, AbstractVector{ScientificTypesBase.OrderedFactor{2}}}}`\n    2:\tSource @259 ⏎ `AbstractVector{ScientificTypesBase.Continuous}`\n"
      },
      "metadata": {},
      "execution_count": 21
@@ -776,7 +776,7 @@
     {
      "output_type": "execute_result",
      "data": {
-      "text/plain": "(coefs = [:x1 => -0.7328956348956909, :x2 => -0.16590563202915437, :x3 => 194.59515890822126, :x4 => 102.71301756136401],\n intercept = 540085.6428739978,)"
+      "text/plain": "(coefs = [:x1 => -0.7328956348956878, :x2 => -0.1659056320291739, :x3 => 194.5951589082211, :x4 => 102.71301756136427],\n intercept = 540085.6428739978,)"
      },
      "metadata": {},
      "execution_count": 22
@@ -794,7 +794,7 @@
     {
      "output_type": "execute_result",
      "data": {
-      "text/plain": "(indim = 87,\n outdim = 4,\n tprincipalvar = 2.463215246230867e9,\n tresidualvar = 157533.26199626923,\n tvar = 2.463372779492863e9,\n mean = [4.369869985656781, 8.45912182482765, 2079.8997362698374, 15106.967565816869, 1.988617961412113, 1.0075417572757137, 1.2343034284921113, 3.4094295100171195, 6.6569194466293435, 1788.3906907879516  …  0.011798454633785222, 0.012122333780595013, 0.006292509138018785, 0.012955165872391617, 0.01466709850552908, 47.560052519317075, -122.21389640494147, 1986.552491556008, 12768.455651691113, 1.9577106371165502],\n principalvars = [2.177071551045086e9, 2.8418139726430327e8, 1.685016083064339e6, 277281.8384131848],)"
+      "text/plain": "(indim = 87,\n outdim = 4,\n tprincipalvar = 2.463215246230865e9,\n tresidualvar = 157533.26199626923,\n tvar = 2.4633727794928613e9,\n mean = [4.369869985656781, 8.45912182482765, 2079.8997362698374, 15106.967565816869, 1.988617961412113, 1.0075417572757137, 1.2343034284921113, 3.4094295100171195, 6.6569194466293435, 1788.3906907879516  …  0.011798454633785222, 0.012122333780595013, 0.006292509138018785, 0.012955165872391617, 0.01466709850552908, 47.56005251931713, -122.21389640494186, 1986.552491556008, 12768.455651691113, 1.9577106371165502],\n principalvars = [2.1770715510450845e9, 2.8418139726430273e8, 1.6850160830643363e6, 277281.8384131831],)"
      },
      "metadata": {},
      "execution_count": 23
@@ -857,7 +857,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\rEvaluating over 6 folds:  33%[========>                ]  ETA: 0:00:23\u001b[K\rEvaluating over 6 folds:  67%[================>        ]  ETA: 0:00:06\u001b[K\rEvaluating over 6 folds:  83%[====================>    ]  ETA: 0:00:03\u001b[K\rEvaluating over 6 folds: 100%[=========================] Time: 0:00:13\u001b[K\n"
+      "\rEvaluating over 6 folds:  33%[========>                ]  ETA: 0:00:18\u001b[K\rEvaluating over 6 folds:  67%[================>        ]  ETA: 0:00:05\u001b[K\rEvaluating over 6 folds:  83%[====================>    ]  ETA: 0:00:02\u001b[K\rEvaluating over 6 folds: 100%[=========================] Time: 0:00:10\u001b[K\n"
      ]
     },
     {
@@ -907,7 +907,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\rEvaluating over 6 folds:  33%[========>                ]  ETA: 0:00:22\u001b[K\rEvaluating over 6 folds:  50%[============>            ]  ETA: 0:00:15\u001b[K\rEvaluating over 6 folds:  67%[================>        ]  ETA: 0:00:09\u001b[K\rEvaluating over 6 folds:  83%[====================>    ]  ETA: 0:00:04\u001b[K\rEvaluating over 6 folds: 100%[=========================] Time: 0:00:25\u001b[K\n"
+      "\rEvaluating over 6 folds:  33%[========>                ]  ETA: 0:00:16\u001b[K\rEvaluating over 6 folds:  50%[============>            ]  ETA: 0:00:11\u001b[K\rEvaluating over 6 folds:  67%[================>        ]  ETA: 0:00:07\u001b[K\rEvaluating over 6 folds:  83%[====================>    ]  ETA: 0:00:03\u001b[K\rEvaluating over 6 folds: 100%[=========================] Time: 0:00:18\u001b[K\n"
      ]
     },
     {
@@ -938,7 +938,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\rEvaluating over 6 folds:  33%[========>                ]  ETA: 0:00:08\u001b[K\rEvaluating over 6 folds:  50%[============>            ]  ETA: 0:00:04\u001b[K\rEvaluating over 6 folds:  67%[================>        ]  ETA: 0:00:02\u001b[K\rEvaluating over 6 folds:  83%[====================>    ]  ETA: 0:00:01\u001b[K\rEvaluating over 6 folds: 100%[=========================] Time: 0:00:05\u001b[K\n"
+      "\rEvaluating over 6 folds:  33%[========>                ]  ETA: 0:00:07\u001b[K\rEvaluating over 6 folds:  50%[============>            ]  ETA: 0:00:04\u001b[K\rEvaluating over 6 folds:  67%[================>        ]  ETA: 0:00:02\u001b[K\rEvaluating over 6 folds:  83%[====================>    ]  ETA: 0:00:01\u001b[K\rEvaluating over 6 folds: 100%[=========================] Time: 0:00:04\u001b[K\n"
      ]
     },
     {
@@ -1087,11 +1087,11 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.7.1"
+   "version": "1.6.5"
   },
   "kernelspec": {
-   "name": "julia-1.7",
-   "display_name": "Julia 1.7.1",
+   "name": "julia-1.6",
+   "display_name": "Julia 1.6.5",
    "language": "julia"
   }
  },

--- a/notebooks/03_pipelines/notebook.ipynb
+++ b/notebooks/03_pipelines/notebook.ipynb
@@ -58,7 +58,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "The package environment has been created using **Julia 1.6** and may not\n",
+    "The package environment has been created using **Julia 1.7** and may not\n",
     "instantiate properly for other Julia versions."
    ],
    "metadata": {}
@@ -138,8 +138,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "mean(x) = 0.47253618410343046\n",
-      "std(x) = 0.3027701918985175\n"
+      "mean(x) = 0.48986440325190694\n",
+      "std(x) = 0.2875350590235868\n"
      ]
     }
    ],
@@ -160,8 +160,8 @@
      "output_type": "stream",
      "text": [
       "[ Info: Training Machine{Standardizer,…}.\n",
-      "mean(xhat) = 5.773159728050814e-17\n",
-      "std(xhat) = 1.0\n"
+      "mean(xhat) = -4.551914400963141e-16\n",
+      "std(xhat) = 0.9999999999999999\n"
      ]
     }
    ],
@@ -669,7 +669,7 @@
     {
      "output_type": "execute_result",
      "data": {
-      "text/plain": "Machine{DeterministicPipeline{NamedTuple{,…},…},…} trained 2 times; caches data\n  model: MLJBase.DeterministicPipeline{NamedTuple{(:continuous_encoder, :pca, :ridge_regressor), Tuple{MLJModelInterface.Unsupervised, MLJModelInterface.Unsupervised, MLJModelInterface.Deterministic}}, MLJModelInterface.predict}\n  args: \n    1:\tSource @864 ⏎ `ScientificTypesBase.Table{Union{AbstractVector{ScientificTypesBase.Continuous}, AbstractVector{ScientificTypesBase.Multiclass{70}}, AbstractVector{ScientificTypesBase.OrderedFactor{6}}, AbstractVector{ScientificTypesBase.OrderedFactor{13}}, AbstractVector{ScientificTypesBase.OrderedFactor{30}}, AbstractVector{ScientificTypesBase.OrderedFactor{5}}, AbstractVector{ScientificTypesBase.OrderedFactor{12}}, AbstractVector{ScientificTypesBase.OrderedFactor{2}}}}`\n    2:\tSource @134 ⏎ `AbstractVector{ScientificTypesBase.Continuous}`\n"
+      "text/plain": "Machine{DeterministicPipeline{NamedTuple{,…},…},…} trained 2 times; caches data\n  model: MLJBase.DeterministicPipeline{NamedTuple{(:continuous_encoder, :pca, :ridge_regressor), Tuple{MLJModelInterface.Unsupervised, MLJModelInterface.Unsupervised, MLJModelInterface.Deterministic}}, MLJModelInterface.predict}\n  args: \n    1:\tSource @697 ⏎ `ScientificTypesBase.Table{Union{AbstractVector{ScientificTypesBase.Continuous}, AbstractVector{ScientificTypesBase.Multiclass{70}}, AbstractVector{ScientificTypesBase.OrderedFactor{6}}, AbstractVector{ScientificTypesBase.OrderedFactor{13}}, AbstractVector{ScientificTypesBase.OrderedFactor{30}}, AbstractVector{ScientificTypesBase.OrderedFactor{5}}, AbstractVector{ScientificTypesBase.OrderedFactor{12}}, AbstractVector{ScientificTypesBase.OrderedFactor{2}}}}`\n    2:\tSource @379 ⏎ `AbstractVector{ScientificTypesBase.Continuous}`\n"
      },
      "metadata": {},
      "execution_count": 19
@@ -697,7 +697,7 @@
     {
      "output_type": "execute_result",
      "data": {
-      "text/plain": "Machine{DeterministicPipeline{NamedTuple{,…},…},…} trained 3 times; caches data\n  model: MLJBase.DeterministicPipeline{NamedTuple{(:continuous_encoder, :pca, :ridge_regressor), Tuple{MLJModelInterface.Unsupervised, MLJModelInterface.Unsupervised, MLJModelInterface.Deterministic}}, MLJModelInterface.predict}\n  args: \n    1:\tSource @864 ⏎ `ScientificTypesBase.Table{Union{AbstractVector{ScientificTypesBase.Continuous}, AbstractVector{ScientificTypesBase.Multiclass{70}}, AbstractVector{ScientificTypesBase.OrderedFactor{6}}, AbstractVector{ScientificTypesBase.OrderedFactor{13}}, AbstractVector{ScientificTypesBase.OrderedFactor{30}}, AbstractVector{ScientificTypesBase.OrderedFactor{5}}, AbstractVector{ScientificTypesBase.OrderedFactor{12}}, AbstractVector{ScientificTypesBase.OrderedFactor{2}}}}`\n    2:\tSource @134 ⏎ `AbstractVector{ScientificTypesBase.Continuous}`\n"
+      "text/plain": "Machine{DeterministicPipeline{NamedTuple{,…},…},…} trained 3 times; caches data\n  model: MLJBase.DeterministicPipeline{NamedTuple{(:continuous_encoder, :pca, :ridge_regressor), Tuple{MLJModelInterface.Unsupervised, MLJModelInterface.Unsupervised, MLJModelInterface.Deterministic}}, MLJModelInterface.predict}\n  args: \n    1:\tSource @697 ⏎ `ScientificTypesBase.Table{Union{AbstractVector{ScientificTypesBase.Continuous}, AbstractVector{ScientificTypesBase.Multiclass{70}}, AbstractVector{ScientificTypesBase.OrderedFactor{6}}, AbstractVector{ScientificTypesBase.OrderedFactor{13}}, AbstractVector{ScientificTypesBase.OrderedFactor{30}}, AbstractVector{ScientificTypesBase.OrderedFactor{5}}, AbstractVector{ScientificTypesBase.OrderedFactor{12}}, AbstractVector{ScientificTypesBase.OrderedFactor{2}}}}`\n    2:\tSource @379 ⏎ `AbstractVector{ScientificTypesBase.Continuous}`\n"
      },
      "metadata": {},
      "execution_count": 20
@@ -741,7 +741,7 @@
     {
      "output_type": "execute_result",
      "data": {
-      "text/plain": "Machine{DeterministicPipeline{NamedTuple{,…},…},…} trained 4 times; caches data\n  model: MLJBase.DeterministicPipeline{NamedTuple{(:continuous_encoder, :pca, :ridge_regressor), Tuple{MLJModelInterface.Unsupervised, MLJModelInterface.Unsupervised, MLJModelInterface.Deterministic}}, MLJModelInterface.predict}\n  args: \n    1:\tSource @864 ⏎ `ScientificTypesBase.Table{Union{AbstractVector{ScientificTypesBase.Continuous}, AbstractVector{ScientificTypesBase.Multiclass{70}}, AbstractVector{ScientificTypesBase.OrderedFactor{6}}, AbstractVector{ScientificTypesBase.OrderedFactor{13}}, AbstractVector{ScientificTypesBase.OrderedFactor{30}}, AbstractVector{ScientificTypesBase.OrderedFactor{5}}, AbstractVector{ScientificTypesBase.OrderedFactor{12}}, AbstractVector{ScientificTypesBase.OrderedFactor{2}}}}`\n    2:\tSource @134 ⏎ `AbstractVector{ScientificTypesBase.Continuous}`\n"
+      "text/plain": "Machine{DeterministicPipeline{NamedTuple{,…},…},…} trained 4 times; caches data\n  model: MLJBase.DeterministicPipeline{NamedTuple{(:continuous_encoder, :pca, :ridge_regressor), Tuple{MLJModelInterface.Unsupervised, MLJModelInterface.Unsupervised, MLJModelInterface.Deterministic}}, MLJModelInterface.predict}\n  args: \n    1:\tSource @697 ⏎ `ScientificTypesBase.Table{Union{AbstractVector{ScientificTypesBase.Continuous}, AbstractVector{ScientificTypesBase.Multiclass{70}}, AbstractVector{ScientificTypesBase.OrderedFactor{6}}, AbstractVector{ScientificTypesBase.OrderedFactor{13}}, AbstractVector{ScientificTypesBase.OrderedFactor{30}}, AbstractVector{ScientificTypesBase.OrderedFactor{5}}, AbstractVector{ScientificTypesBase.OrderedFactor{12}}, AbstractVector{ScientificTypesBase.OrderedFactor{2}}}}`\n    2:\tSource @379 ⏎ `AbstractVector{ScientificTypesBase.Continuous}`\n"
      },
      "metadata": {},
      "execution_count": 21
@@ -857,7 +857,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\rEvaluating over 6 folds:  33%[========>                ]  ETA: 0:00:12\u001b[K\rEvaluating over 6 folds:  83%[====================>    ]  ETA: 0:00:01\u001b[K\rEvaluating over 6 folds: 100%[=========================] Time: 0:00:06\u001b[K\n"
+      "\rEvaluating over 6 folds:  33%[========>                ]  ETA: 0:00:23\u001b[K\rEvaluating over 6 folds:  67%[================>        ]  ETA: 0:00:06\u001b[K\rEvaluating over 6 folds:  83%[====================>    ]  ETA: 0:00:03\u001b[K\rEvaluating over 6 folds: 100%[=========================] Time: 0:00:13\u001b[K\n"
      ]
     },
     {
@@ -907,7 +907,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\rEvaluating over 6 folds:  33%[========>                ]  ETA: 0:00:14\u001b[K\rEvaluating over 6 folds:  50%[============>            ]  ETA: 0:00:09\u001b[K\rEvaluating over 6 folds:  67%[================>        ]  ETA: 0:00:05\u001b[K\rEvaluating over 6 folds:  83%[====================>    ]  ETA: 0:00:03\u001b[K\rEvaluating over 6 folds: 100%[=========================] Time: 0:00:15\u001b[K\n"
+      "\rEvaluating over 6 folds:  33%[========>                ]  ETA: 0:00:22\u001b[K\rEvaluating over 6 folds:  50%[============>            ]  ETA: 0:00:15\u001b[K\rEvaluating over 6 folds:  67%[================>        ]  ETA: 0:00:09\u001b[K\rEvaluating over 6 folds:  83%[====================>    ]  ETA: 0:00:04\u001b[K\rEvaluating over 6 folds: 100%[=========================] Time: 0:00:25\u001b[K\n"
      ]
     },
     {
@@ -938,7 +938,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\rEvaluating over 6 folds:  33%[========>                ]  ETA: 0:00:06\u001b[K\rEvaluating over 6 folds:  50%[============>            ]  ETA: 0:00:03\u001b[K\rEvaluating over 6 folds:  67%[================>        ]  ETA: 0:00:02\u001b[K\rEvaluating over 6 folds:  83%[====================>    ]  ETA: 0:00:01\u001b[K\rEvaluating over 6 folds: 100%[=========================] Time: 0:00:03\u001b[K\n"
+      "\rEvaluating over 6 folds:  33%[========>                ]  ETA: 0:00:08\u001b[K\rEvaluating over 6 folds:  50%[============>            ]  ETA: 0:00:04\u001b[K\rEvaluating over 6 folds:  67%[================>        ]  ETA: 0:00:02\u001b[K\rEvaluating over 6 folds:  83%[====================>    ]  ETA: 0:00:01\u001b[K\rEvaluating over 6 folds: 100%[=========================] Time: 0:00:05\u001b[K\n"
      ]
     },
     {

--- a/notebooks/03_pipelines/notebook.ipynb
+++ b/notebooks/03_pipelines/notebook.ipynb
@@ -1,0 +1,1099 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Machine Learning in Julia (continued)"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "An introduction to the\n",
+    "[MLJ](https://alan-turing-institute.github.io/MLJ.jl/stable/)\n",
+    "toolbox."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Set-up"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Inspect Julia version:"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "v\"1.7.1\""
+     },
+     "metadata": {},
+     "execution_count": 1
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "VERSION"
+   ],
+   "metadata": {},
+   "execution_count": 1
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "The following instantiates a package environment."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "The package environment has been created using **Julia 1.6** and may not\n",
+    "instantiate properly for other Julia versions."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Activating project at `~/GoogleDrive/Julia/MLJ/MLJTutorial/notebooks/03_pipelines/env`\n"
+     ]
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "using Pkg\n",
+    "Pkg.activate(\"env\")\n",
+    "Pkg.instantiate()"
+   ],
+   "metadata": {},
+   "execution_count": 2
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## General resources"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "- [MLJ Cheatsheet](https://alan-turing-institute.github.io/MLJ.jl/dev/mlj_cheatsheet/)\n",
+    "- [Common MLJ Workflows](https://alan-turing-institute.github.io/MLJ.jl/dev/common_mlj_workflows/)\n",
+    "- [MLJ manual](https://alan-turing-institute.github.io/MLJ.jl/dev/)\n",
+    "- [Data Science Tutorials in Julia](https://juliaai.github.io/DataScienceTutorials.jl/)"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Part 3 - Transformers and Pipelines"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Transformers"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Unsupervised models, which receive no target `y` during training,\n",
+    "always have a `transform` operation. They sometimes also support an\n",
+    "`inverse_transform` operation, with obvious meaning, and sometimes\n",
+    "support a `predict` operation (see the clustering example discussed\n",
+    "[here](https://alan-turing-institute.github.io/MLJ.jl/dev/transformers/#Transformers-that-also-predict-1)).\n",
+    "Otherwise, they are handled much like supervised models."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Here's a simple standardization example:"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean(x) = 0.47253618410343046\n",
+      "std(x) = 0.3027701918985175\n"
+     ]
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "using MLJ\n",
+    "\n",
+    "x = rand(100);\n",
+    "@show mean(x) std(x);"
+   ],
+   "metadata": {},
+   "execution_count": 3
+  },
+  {
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ Info: Training Machine{Standardizer,…}.\n",
+      "mean(xhat) = 5.773159728050814e-17\n",
+      "std(xhat) = 1.0\n"
+     ]
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "model = Standardizer() # a built-in model\n",
+    "mach = machine(model, x)\n",
+    "fit!(mach)\n",
+    "xhat = transform(mach, x);\n",
+    "@show mean(xhat) std(xhat);"
+   ],
+   "metadata": {},
+   "execution_count": 4
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "This particular model has an `inverse_transform`:"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "true"
+     },
+     "metadata": {},
+     "execution_count": 5
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "inverse_transform(mach, xhat) ≈ x"
+   ],
+   "metadata": {},
+   "execution_count": 5
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Re-encoding the King County House data as continuous"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "For further illustrations of transformers, let's re-encode *all* of the\n",
+    "King County House input features (see [Ex\n",
+    "3](#exercise-3-fixing-scitypes-in-a-table)) into a set of `Continuous`\n",
+    "features. We do this with the `ContinuousEncoder` model, which, by\n",
+    "default, will:"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "- one-hot encode all `Multiclass` features\n",
+    "- coerce all `OrderedFactor` features to `Continuous` ones\n",
+    "- coerce all `Count` features to `Continuous` ones (there aren't any)\n",
+    "- drop any remaining non-Continuous features (none of these either)"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "First, we reload the data and fix the scitypes (Exercise 3):"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "┌───────────────┬───────────────────┬───────────────────────────────────┐\n│\u001b[22m names         \u001b[0m│\u001b[22m scitypes          \u001b[0m│\u001b[22m types                             \u001b[0m│\n├───────────────┼───────────────────┼───────────────────────────────────┤\n│ price         │ Continuous        │ Float64                           │\n│ bedrooms      │ OrderedFactor{13} │ CategoricalValue{Int64, UInt32}   │\n│ bathrooms     │ OrderedFactor{30} │ CategoricalValue{Float64, UInt32} │\n│ sqft_living   │ Continuous        │ Float64                           │\n│ sqft_lot      │ Continuous        │ Float64                           │\n│ floors        │ OrderedFactor{6}  │ CategoricalValue{Float64, UInt32} │\n│ waterfront    │ OrderedFactor{2}  │ CategoricalValue{Int64, UInt32}   │\n│ view          │ OrderedFactor{5}  │ CategoricalValue{Int64, UInt32}   │\n│ condition     │ OrderedFactor{5}  │ CategoricalValue{Int64, UInt32}   │\n│ grade         │ OrderedFactor{12} │ CategoricalValue{Int64, UInt32}   │\n│ sqft_above    │ Continuous        │ Float64                           │\n│ sqft_basement │ Continuous        │ Float64                           │\n│ yr_built      │ Continuous        │ Float64                           │\n│ zipcode       │ Multiclass{70}    │ CategoricalValue{Int64, UInt32}   │\n│ lat           │ Continuous        │ Float64                           │\n│ long          │ Continuous        │ Float64                           │\n│       ⋮       │         ⋮         │                 ⋮                 │\n└───────────────┴───────────────────┴───────────────────────────────────┘\n\u001b[36m                                                           3 rows omitted\u001b[0m\n"
+     },
+     "metadata": {},
+     "execution_count": 6
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "using UrlDownload, CSV\n",
+    "import DataFrames\n",
+    "house_csv = urldownload(\"https://raw.githubusercontent.com/ablaom/\"*\n",
+    "                        \"MachineLearningInJulia2020/for-MLJ-version-0.16/\"*\n",
+    "                        \"data/house.csv\");\n",
+    "house = DataFrames.DataFrame(house_csv)\n",
+    "coerce!(house, autotype(house_csv));\n",
+    "coerce!(house, Count => Continuous, :zipcode => Multiclass);\n",
+    "schema(house)"
+   ],
+   "metadata": {},
+   "execution_count": 6
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "y, X = unpack(house, ==(:price), rng=123);"
+   ],
+   "metadata": {},
+   "execution_count": 7
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Instantiate the unsupervised model (transformer):"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "ContinuousEncoder(\n    drop_last = false,\n    one_hot_ordered_factors = false)"
+     },
+     "metadata": {},
+     "execution_count": 8
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "encoder = ContinuousEncoder() # a built-in model; no need to @load it"
+   ],
+   "metadata": {},
+   "execution_count": 8
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Bind the model to the data and fit!"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ Info: Training Machine{ContinuousEncoder,…}.\n"
+     ]
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "mach = machine(encoder, X) |> fit!;"
+   ],
+   "metadata": {},
+   "execution_count": 9
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Transform and inspect the result:"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "┌────────────────┬────────────┬─────────┐\n│\u001b[22m names          \u001b[0m│\u001b[22m scitypes   \u001b[0m│\u001b[22m types   \u001b[0m│\n├────────────────┼────────────┼─────────┤\n│ bedrooms       │ Continuous │ Float64 │\n│ bathrooms      │ Continuous │ Float64 │\n│ sqft_living    │ Continuous │ Float64 │\n│ sqft_lot       │ Continuous │ Float64 │\n│ floors         │ Continuous │ Float64 │\n│ waterfront     │ Continuous │ Float64 │\n│ view           │ Continuous │ Float64 │\n│ condition      │ Continuous │ Float64 │\n│ grade          │ Continuous │ Float64 │\n│ sqft_above     │ Continuous │ Float64 │\n│ sqft_basement  │ Continuous │ Float64 │\n│ yr_built       │ Continuous │ Float64 │\n│ zipcode__98001 │ Continuous │ Float64 │\n│ zipcode__98002 │ Continuous │ Float64 │\n│ zipcode__98003 │ Continuous │ Float64 │\n│ zipcode__98004 │ Continuous │ Float64 │\n│       ⋮        │     ⋮      │    ⋮    │\n└────────────────┴────────────┴─────────┘\n\u001b[36m                          71 rows omitted\u001b[0m\n"
+     },
+     "metadata": {},
+     "execution_count": 10
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "Xcont = transform(mach, X);\n",
+    "schema(Xcont)"
+   ],
+   "metadata": {},
+   "execution_count": 10
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### More transformers"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Here's how to list all of MLJ's unsupervised models:"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "60-element Vector{NamedTuple{(:name, :package_name, :is_supervised, :abstract_type, :deep_properties, :docstring, :fit_data_scitype, :hyperparameter_ranges, :hyperparameter_types, :hyperparameters, :implemented_methods, :inverse_transform_scitype, :is_pure_julia, :is_wrapper, :iteration_parameter, :load_path, :package_license, :package_url, :package_uuid, :predict_scitype, :prediction_type, :supports_class_weights, :supports_online, :supports_training_losses, :supports_weights, :transform_scitype, :input_scitype, :target_scitype, :output_scitype)}}:\n (name = ABODDetector, package_name = OutlierDetectionNeighbors, ... )\n (name = ABODDetector, package_name = OutlierDetectionPython, ... )\n (name = AEDetector, package_name = OutlierDetectionNetworks, ... )\n (name = AffinityPropagation, package_name = ScikitLearn, ... )\n (name = AgglomerativeClustering, package_name = ScikitLearn, ... )\n (name = BM25Transformer, package_name = MLJText, ... )\n (name = BagOfWordsTransformer, package_name = MLJText, ... )\n (name = Birch, package_name = ScikitLearn, ... )\n (name = CBLOFDetector, package_name = OutlierDetectionPython, ... )\n (name = COFDetector, package_name = OutlierDetectionNeighbors, ... )\n ⋮\n (name = SpectralClustering, package_name = ScikitLearn, ... )\n (name = Standardizer, package_name = MLJModels, ... )\n (name = TSVDTransformer, package_name = TSVD, ... )\n (name = TfidfTransformer, package_name = MLJText, ... )\n (name = UnivariateBoxCoxTransformer, package_name = MLJModels, ... )\n (name = UnivariateDiscretizer, package_name = MLJModels, ... )\n (name = UnivariateFillImputer, package_name = MLJModels, ... )\n (name = UnivariateStandardizer, package_name = MLJModels, ... )\n (name = UnivariateTimeTypeToContinuous, package_name = MLJModels, ... )"
+     },
+     "metadata": {},
+     "execution_count": 11
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "models(m->!m.is_supervised)"
+   ],
+   "metadata": {},
+   "execution_count": 11
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Some commonly used ones are built-in (do not require `@load`ing):"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "model type                  | does what?\n",
+    "----------------------------|----------------------------------------------\n",
+    "ContinuousEncoder | transform input table to a table of `Continuous` features (see above)\n",
+    "FeatureSelector | retain or dump selected features\n",
+    "FillImputer | impute missing values\n",
+    "OneHotEncoder | one-hot encoder `Multiclass` (and optionally `OrderedFactor`) features\n",
+    "Standardizer | standardize (whiten) a vector or all `Continuous` features of a table\n",
+    "UnivariateBoxCoxTransformer | apply a learned Box-Cox transformation to a vector\n",
+    "UnivariateDiscretizer | discretize a `Continuous` vector, and hence render its elscitypw `OrderedFactor`"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "In addition to \"dynamic\" transformers (ones that learn something\n",
+    "from the data and must be `fit!`) users can wrap ordinary functions\n",
+    "as transformers, and such *static* transformers can depend on\n",
+    "parameters, like the dynamic ones. See\n",
+    "[here](https://alan-turing-institute.github.io/MLJ.jl/dev/transformers/#Static-transformers-1)\n",
+    "for how to define your own static transformers."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Pipelines"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "87"
+     },
+     "metadata": {},
+     "execution_count": 12
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "length(schema(Xcont).names)"
+   ],
+   "metadata": {},
+   "execution_count": 12
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Let's suppose that additionally we'd like to reduce the dimension of\n",
+    "our data.  A model that will do this is `PCA` from\n",
+    "`MultivariateStats.jl`:"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ Info: For silent loading, specify `verbosity=0`. \n",
+      "import MLJMultivariateStatsInterface ✔\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "PCA(\n    maxoutdim = 0,\n    method = :auto,\n    pratio = 0.99,\n    mean = nothing)"
+     },
+     "metadata": {},
+     "execution_count": 13
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "PCA = @load PCA\n",
+    "reducer = PCA()"
+   ],
+   "metadata": {},
+   "execution_count": 13
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Now, rather simply repeating the work-flow above, applying the new\n",
+    "transformation to `Xcont`, we can combine both the encoding and the\n",
+    "dimension-reducing models into a single model, known as a\n",
+    "*pipeline*. While MLJ offers a powerful interface for composing\n",
+    "models in a variety of ways, we'll stick to these simplest class of\n",
+    "composite models for now. The simplest way to construct a pipeline\n",
+    "is using the Julia's `|>` syntax:"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "UnsupervisedPipeline(\n    continuous_encoder = ContinuousEncoder(\n            drop_last = false,\n            one_hot_ordered_factors = false),\n    pca = PCA(\n            maxoutdim = 0,\n            method = :auto,\n            pratio = 0.99,\n            mean = nothing),\n    cache = true)"
+     },
+     "metadata": {},
+     "execution_count": 14
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "pipe = encoder |> reducer"
+   ],
+   "metadata": {},
+   "execution_count": 14
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Notice that the model `pipe` has other models as hyperparameters\n",
+    "(with names automatically generated based on the mode type\n",
+    "name). The hyperparameters of the component models are are now\n",
+    "*nested*, but we can still access them:"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pipe.pca.pratio = 0.99\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "0.85"
+     },
+     "metadata": {},
+     "execution_count": 15
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "@show pipe.pca.pratio\n",
+    "pipe.pca.pratio = 0.85"
+   ],
+   "metadata": {},
+   "execution_count": 15
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "The pipeline model behaves like any other transformer:"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ Info: Training Machine{UnsupervisedPipeline{NamedTuple{,…},…},…}.\n",
+      "[ Info: Training Machine{ContinuousEncoder,…}.\n",
+      "[ Info: Training Machine{PCA,…}.\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "┌───────┬────────────┬─────────┐\n│\u001b[22m names \u001b[0m│\u001b[22m scitypes   \u001b[0m│\u001b[22m types   \u001b[0m│\n├───────┼────────────┼─────────┤\n│ x1    │ Continuous │ Float64 │\n└───────┴────────────┴─────────┘\n"
+     },
+     "metadata": {},
+     "execution_count": 16
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "mach = machine(pipe, X)\n",
+    "fit!(mach)\n",
+    "Xsmall = transform(mach, X)\n",
+    "schema(Xsmall)"
+   ],
+   "metadata": {},
+   "execution_count": 16
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Want to combine this pre-processing with ridge regression?"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ Info: For silent loading, specify `verbosity=0`. \n",
+      "import MLJLinearModels ✔\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "DeterministicPipeline(\n    continuous_encoder = ContinuousEncoder(\n            drop_last = false,\n            one_hot_ordered_factors = false),\n    pca = PCA(\n            maxoutdim = 0,\n            method = :auto,\n            pratio = 0.85,\n            mean = nothing),\n    ridge_regressor = RidgeRegressor(\n            lambda = 1.0,\n            fit_intercept = true,\n            penalize_intercept = false,\n            solver = nothing),\n    cache = true)"
+     },
+     "metadata": {},
+     "execution_count": 17
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "RidgeRegressor = @load RidgeRegressor pkg=MLJLinearModels\n",
+    "rgs = RidgeRegressor()\n",
+    "pipe2 = pipe |> rgs"
+   ],
+   "metadata": {},
+   "execution_count": 17
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Now our pipeline is a supervised model, instead of a transformer,\n",
+    "whose performance we can evaluate:"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "PerformanceEvaluation object with these fields:\n  measure, measurement, operation, per_fold,\n  per_observation, fitted_params_per_fold,\n  report_per_fold, train_test_pairs\nExtract:\n┌─────────────────────┬─────────────┬───────────┬────────────┐\n│\u001b[22m measure             \u001b[0m│\u001b[22m measurement \u001b[0m│\u001b[22m operation \u001b[0m│\u001b[22m per_fold   \u001b[0m│\n├─────────────────────┼─────────────┼───────────┼────────────┤\n│ MeanAbsoluteError() │ 234000.0    │ predict   │ [234000.0] │\n└─────────────────────┴─────────────┴───────────┴────────────┘\n"
+     },
+     "metadata": {},
+     "execution_count": 18
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "mach = machine(pipe2, X, y)\n",
+    "evaluate!(mach, measure=mae, resampling=Holdout()) # CV(nfolds=6) is default"
+   ],
+   "metadata": {},
+   "execution_count": 18
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Training of composite models is \"smart\""
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Now notice what happens if we train on all the data, then change a\n",
+    "regressor hyper-parameter and retrain:"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ Info: Training Machine{DeterministicPipeline{NamedTuple{,…},…},…}.\n",
+      "[ Info: Training Machine{ContinuousEncoder,…}.\n",
+      "[ Info: Training Machine{PCA,…}.\n",
+      "[ Info: Training Machine{RidgeRegressor,…}.\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "Machine{DeterministicPipeline{NamedTuple{,…},…},…} trained 2 times; caches data\n  model: MLJBase.DeterministicPipeline{NamedTuple{(:continuous_encoder, :pca, :ridge_regressor), Tuple{MLJModelInterface.Unsupervised, MLJModelInterface.Unsupervised, MLJModelInterface.Deterministic}}, MLJModelInterface.predict}\n  args: \n    1:\tSource @864 ⏎ `ScientificTypesBase.Table{Union{AbstractVector{ScientificTypesBase.Continuous}, AbstractVector{ScientificTypesBase.Multiclass{70}}, AbstractVector{ScientificTypesBase.OrderedFactor{6}}, AbstractVector{ScientificTypesBase.OrderedFactor{13}}, AbstractVector{ScientificTypesBase.OrderedFactor{30}}, AbstractVector{ScientificTypesBase.OrderedFactor{5}}, AbstractVector{ScientificTypesBase.OrderedFactor{12}}, AbstractVector{ScientificTypesBase.OrderedFactor{2}}}}`\n    2:\tSource @134 ⏎ `AbstractVector{ScientificTypesBase.Continuous}`\n"
+     },
+     "metadata": {},
+     "execution_count": 19
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "fit!(mach)"
+   ],
+   "metadata": {},
+   "execution_count": 19
+  },
+  {
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ Info: Updating Machine{DeterministicPipeline{NamedTuple{,…},…},…}.\n",
+      "[ Info: Not retraining Machine{ContinuousEncoder,…}. Use `force=true` to force.\n",
+      "[ Info: Not retraining Machine{PCA,…}. Use `force=true` to force.\n",
+      "[ Info: Updating Machine{RidgeRegressor,…}.\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "Machine{DeterministicPipeline{NamedTuple{,…},…},…} trained 3 times; caches data\n  model: MLJBase.DeterministicPipeline{NamedTuple{(:continuous_encoder, :pca, :ridge_regressor), Tuple{MLJModelInterface.Unsupervised, MLJModelInterface.Unsupervised, MLJModelInterface.Deterministic}}, MLJModelInterface.predict}\n  args: \n    1:\tSource @864 ⏎ `ScientificTypesBase.Table{Union{AbstractVector{ScientificTypesBase.Continuous}, AbstractVector{ScientificTypesBase.Multiclass{70}}, AbstractVector{ScientificTypesBase.OrderedFactor{6}}, AbstractVector{ScientificTypesBase.OrderedFactor{13}}, AbstractVector{ScientificTypesBase.OrderedFactor{30}}, AbstractVector{ScientificTypesBase.OrderedFactor{5}}, AbstractVector{ScientificTypesBase.OrderedFactor{12}}, AbstractVector{ScientificTypesBase.OrderedFactor{2}}}}`\n    2:\tSource @134 ⏎ `AbstractVector{ScientificTypesBase.Continuous}`\n"
+     },
+     "metadata": {},
+     "execution_count": 20
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "pipe2.ridge_regressor.lambda = 0.1\n",
+    "fit!(mach)"
+   ],
+   "metadata": {},
+   "execution_count": 20
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Second time only the ridge regressor is retrained!"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Mutate a hyper-parameter of the `PCA` model and every model except\n",
+    "the `ContinuousEncoder` (which comes before it will be retrained):"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ Info: Updating Machine{DeterministicPipeline{NamedTuple{,…},…},…}.\n",
+      "[ Info: Not retraining Machine{ContinuousEncoder,…}. Use `force=true` to force.\n",
+      "[ Info: Updating Machine{PCA,…}.\n",
+      "[ Info: Training Machine{RidgeRegressor,…}.\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "Machine{DeterministicPipeline{NamedTuple{,…},…},…} trained 4 times; caches data\n  model: MLJBase.DeterministicPipeline{NamedTuple{(:continuous_encoder, :pca, :ridge_regressor), Tuple{MLJModelInterface.Unsupervised, MLJModelInterface.Unsupervised, MLJModelInterface.Deterministic}}, MLJModelInterface.predict}\n  args: \n    1:\tSource @864 ⏎ `ScientificTypesBase.Table{Union{AbstractVector{ScientificTypesBase.Continuous}, AbstractVector{ScientificTypesBase.Multiclass{70}}, AbstractVector{ScientificTypesBase.OrderedFactor{6}}, AbstractVector{ScientificTypesBase.OrderedFactor{13}}, AbstractVector{ScientificTypesBase.OrderedFactor{30}}, AbstractVector{ScientificTypesBase.OrderedFactor{5}}, AbstractVector{ScientificTypesBase.OrderedFactor{12}}, AbstractVector{ScientificTypesBase.OrderedFactor{2}}}}`\n    2:\tSource @134 ⏎ `AbstractVector{ScientificTypesBase.Continuous}`\n"
+     },
+     "metadata": {},
+     "execution_count": 21
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "pipe2.pca.pratio = 0.9999\n",
+    "fit!(mach)"
+   ],
+   "metadata": {},
+   "execution_count": 21
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Inspecting composite models"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "The dot syntax used above to change the values of *nested*\n",
+    "hyper-parameters is also useful when inspecting the learned\n",
+    "parameters and report generated when training a composite model:"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "(coefs = [:x1 => -0.7328956348956909, :x2 => -0.16590563202915437, :x3 => 194.59515890822126, :x4 => 102.71301756136401],\n intercept = 540085.6428739978,)"
+     },
+     "metadata": {},
+     "execution_count": 22
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "fitted_params(mach).ridge_regressor"
+   ],
+   "metadata": {},
+   "execution_count": 22
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "(indim = 87,\n outdim = 4,\n tprincipalvar = 2.463215246230867e9,\n tresidualvar = 157533.26199626923,\n tvar = 2.463372779492863e9,\n mean = [4.369869985656781, 8.45912182482765, 2079.8997362698374, 15106.967565816869, 1.988617961412113, 1.0075417572757137, 1.2343034284921113, 3.4094295100171195, 6.6569194466293435, 1788.3906907879516  …  0.011798454633785222, 0.012122333780595013, 0.006292509138018785, 0.012955165872391617, 0.01466709850552908, 47.560052519317075, -122.21389640494147, 1986.552491556008, 12768.455651691113, 1.9577106371165502],\n principalvars = [2.177071551045086e9, 2.8418139726430327e8, 1.685016083064339e6, 277281.8384131848],)"
+     },
+     "metadata": {},
+     "execution_count": 23
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "report(mach).pca"
+   ],
+   "metadata": {},
+   "execution_count": 23
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Incorporating target transformations"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Next, suppose that instead of using the raw `:price` as the training\n",
+    "target, we want to use the log-price (a common practice in dealing\n",
+    "with house price data). However, suppose that we still want to\n",
+    "report final *predictions* on the original linear scale (and use\n",
+    "these for evaluation purposes). Then we wrap our supervised model\n",
+    "using `TransformedTargetModel`, which has to key-word arguments\n",
+    "`target` and `inverse`."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "First we'll overload `log` and `exp` for broadcasting:"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "Base.log(v::AbstractArray) = log.(v)\n",
+    "Base.exp(v::AbstractArray) = exp.(v)"
+   ],
+   "metadata": {},
+   "execution_count": 24
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Now for the new pipeline:"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\rEvaluating over 6 folds:  33%[========>                ]  ETA: 0:00:12\u001b[K\rEvaluating over 6 folds:  83%[====================>    ]  ETA: 0:00:01\u001b[K\rEvaluating over 6 folds: 100%[=========================] Time: 0:00:06\u001b[K\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "PerformanceEvaluation object with these fields:\n  measure, measurement, operation, per_fold,\n  per_observation, fitted_params_per_fold,\n  report_per_fold, train_test_pairs\nExtract:\n┌─────────────────────┬─────────────┬───────────┬───────────────────────────────\n│\u001b[22m measure             \u001b[0m│\u001b[22m measurement \u001b[0m│\u001b[22m operation \u001b[0m│\u001b[22m per_fold                    \u001b[0m ⋯\n├─────────────────────┼─────────────┼───────────┼───────────────────────────────\n│ MeanAbsoluteError() │ 162000.0    │ predict   │ [160000.0, 161000.0, 164000. ⋯\n└─────────────────────┴─────────────┴───────────┴───────────────────────────────\n\u001b[36m                                                                1 column omitted\u001b[0m\n"
+     },
+     "metadata": {},
+     "execution_count": 25
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "rgs_log = TransformedTargetModel(rgs, target=log, inverse=exp)\n",
+    "\n",
+    "pipe3 = pipe |> rgs_log\n",
+    "mach = machine(pipe3, X, y)\n",
+    "evaluate!(mach, measure=mae)"
+   ],
+   "metadata": {},
+   "execution_count": 25
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "MLJ will also allow you to insert *learned* target\n",
+    "transformations. For example, we might want to apply\n",
+    "`Standardizer()` to the target, to standardize it, or\n",
+    "`UnivariateBoxCoxTransformer()` to make it look Gaussian. Then\n",
+    "instead of specifying a *function* for `target`, we specify a\n",
+    "unsupervised *model* (or model type). One does not specify `inverse`\n",
+    "because only models implementing `inverse_transform` are\n",
+    "allowed."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Let's see which of these two options results in a better outcome:"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\rEvaluating over 6 folds:  33%[========>                ]  ETA: 0:00:14\u001b[K\rEvaluating over 6 folds:  50%[============>            ]  ETA: 0:00:09\u001b[K\rEvaluating over 6 folds:  67%[================>        ]  ETA: 0:00:05\u001b[K\rEvaluating over 6 folds:  83%[====================>    ]  ETA: 0:00:03\u001b[K\rEvaluating over 6 folds: 100%[=========================] Time: 0:00:15\u001b[K\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "PerformanceEvaluation object with these fields:\n  measure, measurement, operation, per_fold,\n  per_observation, fitted_params_per_fold,\n  report_per_fold, train_test_pairs\nExtract:\n┌─────────────────────┬─────────────┬───────────┬───────────────────────────────\n│\u001b[22m measure             \u001b[0m│\u001b[22m measurement \u001b[0m│\u001b[22m operation \u001b[0m│\u001b[22m per_fold                    \u001b[0m ⋯\n├─────────────────────┼─────────────┼───────────┼───────────────────────────────\n│ MeanAbsoluteError() │ 479000.0    │ predict   │ [168000.0, 172000.0, 170000. ⋯\n└─────────────────────┴─────────────┴───────────┴───────────────────────────────\n\u001b[36m                                                                1 column omitted\u001b[0m\n"
+     },
+     "metadata": {},
+     "execution_count": 26
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "box = UnivariateBoxCoxTransformer(n=20)\n",
+    "stand = Standardizer()\n",
+    "\n",
+    "rgs_box = TransformedTargetModel(rgs, target=box)\n",
+    "pipe4 = pipe |> rgs_box\n",
+    "mach = machine(pipe4, X, y)\n",
+    "evaluate!(mach, measure=mae)"
+   ],
+   "metadata": {},
+   "execution_count": 26
+  },
+  {
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\rEvaluating over 6 folds:  33%[========>                ]  ETA: 0:00:06\u001b[K\rEvaluating over 6 folds:  50%[============>            ]  ETA: 0:00:03\u001b[K\rEvaluating over 6 folds:  67%[================>        ]  ETA: 0:00:02\u001b[K\rEvaluating over 6 folds:  83%[====================>    ]  ETA: 0:00:01\u001b[K\rEvaluating over 6 folds: 100%[=========================] Time: 0:00:03\u001b[K\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "PerformanceEvaluation object with these fields:\n  measure, measurement, operation, per_fold,\n  per_observation, fitted_params_per_fold,\n  report_per_fold, train_test_pairs\nExtract:\n┌─────────────────────┬─────────────┬───────────┬───────────────────────────────\n│\u001b[22m measure             \u001b[0m│\u001b[22m measurement \u001b[0m│\u001b[22m operation \u001b[0m│\u001b[22m per_fold                    \u001b[0m ⋯\n├─────────────────────┼─────────────┼───────────┼───────────────────────────────\n│ MeanAbsoluteError() │ 172000.0    │ predict   │ [173000.0, 171000.0, 172000. ⋯\n└─────────────────────┴─────────────┴───────────┴───────────────────────────────\n\u001b[36m                                                                1 column omitted\u001b[0m\n"
+     },
+     "metadata": {},
+     "execution_count": 27
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "pipe4.transformed_target_model_deterministic.target = stand\n",
+    "evaluate!(mach, measure=mae)"
+   ],
+   "metadata": {},
+   "execution_count": 27
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Resources for Part 3"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "- From the MLJ manual:\n",
+    "    - [Transformers and other unsupervised models](https://alan-turing-institute.github.io/MLJ.jl/dev/transformers/)\n",
+    "    - [Linear pipelines](https://alan-turing-institute.github.io/MLJ.jl/dev/linear_pipelines/#Linear-Pipelines)\n",
+    "- From Data Science Tutorials:\n",
+    "    - [Composing models](https://juliaai.github.io/DataScienceTutorials.jl/getting-started/composing-models/)"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Exercises for Part 3"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### Exercise 7"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Consider again the Horse Colic classification problem considered in\n",
+    "Exercise 6, but with all features, `Finite` and `Infinite`:"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "┌─────────────────────────┬──────────────────┬──────────────────────────────────\n│\u001b[22m names                   \u001b[0m│\u001b[22m scitypes         \u001b[0m│\u001b[22m types                          \u001b[0m ⋯\n├─────────────────────────┼──────────────────┼──────────────────────────────────\n│ surgery                 │ Multiclass{2}    │ CategoricalValue{Int64, UInt32} ⋯\n│ age                     │ Multiclass{2}    │ CategoricalValue{Int64, UInt32} ⋯\n│ rectal_temperature      │ Continuous       │ Float64                         ⋯\n│ pulse                   │ Continuous       │ Float64                         ⋯\n│ respiratory_rate        │ Continuous       │ Float64                         ⋯\n│ temperature_extremities │ OrderedFactor{4} │ CategoricalValue{Int64, UInt32} ⋯\n│ mucous_membranes        │ Multiclass{6}    │ CategoricalValue{Int64, UInt32} ⋯\n│ capillary_refill_time   │ Multiclass{3}    │ CategoricalValue{Int64, UInt32} ⋯\n│ pain                    │ OrderedFactor{5} │ CategoricalValue{Int64, UInt32} ⋯\n│ peristalsis             │ OrderedFactor{4} │ CategoricalValue{Int64, UInt32} ⋯\n│ abdominal_distension    │ OrderedFactor{4} │ CategoricalValue{Int64, UInt32} ⋯\n│ packed_cell_volume      │ Continuous       │ Float64                         ⋯\n│ total_protein           │ Continuous       │ Float64                         ⋯\n│ surgical_lesion         │ OrderedFactor{2} │ CategoricalValue{Int64, UInt32} ⋯\n│ cp_data                 │ Multiclass{2}    │ CategoricalValue{Int64, UInt32} ⋯\n└─────────────────────────┴──────────────────┴──────────────────────────────────\n"
+     },
+     "metadata": {},
+     "execution_count": 28
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "csv_file = urldownload(\"https://raw.githubusercontent.com/ablaom/\"*\n",
+    "                   \"MachineLearningInJulia2020/\"*\n",
+    "                   \"for-MLJ-version-0.16/data/horse.csv\");\n",
+    "horse = DataFrames.DataFrame(csv_file); # convert to data frame\n",
+    "coerce!(horse, autotype(horse));\n",
+    "coerce!(horse, Count => Continuous);\n",
+    "coerce!(horse,\n",
+    "        :surgery               => Multiclass,\n",
+    "        :age                   => Multiclass,\n",
+    "        :mucous_membranes      => Multiclass,\n",
+    "        :capillary_refill_time => Multiclass,\n",
+    "        :outcome               => Multiclass,\n",
+    "        :cp_data               => Multiclass);\n",
+    "\n",
+    "y, X = unpack(horse, ==(:outcome));\n",
+    "schema(X)"
+   ],
+   "metadata": {},
+   "execution_count": 28
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "(a) Define a pipeline that:\n",
+    "- uses `Standardizer` to ensure that features that are already\n",
+    "  continuous are centered at zero and have unit variance\n",
+    "- re-encodes the full set of features as `Continuous`, using\n",
+    "  `ContinuousEncoder`\n",
+    "- uses the `KMeans` clustering model from `Clustering.jl`\n",
+    "  to reduce the dimension of the feature space to `k=10`.\n",
+    "- trains a `EvoTreeClassifier` (a gradient tree boosting\n",
+    "  algorithm in `EvoTrees.jl`) on the reduced data, using\n",
+    "  `nrounds=50` and default values for the other\n",
+    "   hyper-parameters"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "(b) Evaluate the pipeline on all data, using 6-fold cross-validation\n",
+    "and `cross_entropy` loss."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "&star;(c) Plot a learning curve which examines the effect on this loss\n",
+    "as the tree booster parameter `max_depth` varies from 2 to 10."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "<a id='part-4-tuning-hyper-parameters'></a>"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "---\n",
+    "\n",
+    "*This notebook was generated using [Literate.jl](https://github.com/fredrikekre/Literate.jl).*"
+   ],
+   "metadata": {}
+  }
+ ],
+ "nbformat_minor": 3,
+ "metadata": {
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.7.1"
+  },
+  "kernelspec": {
+   "name": "julia-1.7",
+   "display_name": "Julia 1.7.1",
+   "language": "julia"
+  }
+ },
+ "nbformat": 4
+}

--- a/notebooks/03_pipelines/notebook.jl
+++ b/notebooks/03_pipelines/notebook.jl
@@ -13,7 +13,7 @@ VERSION
 
 # The following instantiates a package environment.
 
-# The package environment has been created using **Julia 1.7** and may not
+# The package environment has been created using **Julia 1.6** and may not
 # instantiate properly for other Julia versions.
 
 using Pkg

--- a/notebooks/03_pipelines/notebook.jl
+++ b/notebooks/03_pipelines/notebook.jl
@@ -13,7 +13,7 @@ VERSION
 
 # The following instantiates a package environment.
 
-# The package environment has been created using **Julia 1.6** and may not
+# The package environment has been created using **Julia 1.7** and may not
 # instantiate properly for other Julia versions.
 
 using Pkg

--- a/notebooks/03_pipelines/notebook.unexecuted.ipynb
+++ b/notebooks/03_pipelines/notebook.unexecuted.ipynb
@@ -49,7 +49,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "The package environment has been created using **Julia 1.7** and may not\n",
+    "The package environment has been created using **Julia 1.6** and may not\n",
     "instantiate properly for other Julia versions."
    ],
    "metadata": {}
@@ -771,11 +771,11 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.7.1"
+   "version": "1.6.5"
   },
   "kernelspec": {
-   "name": "julia-1.7",
-   "display_name": "Julia 1.7.1",
+   "name": "julia-1.6",
+   "display_name": "Julia 1.6.5",
    "language": "julia"
   }
  },

--- a/notebooks/03_pipelines/notebook.unexecuted.ipynb
+++ b/notebooks/03_pipelines/notebook.unexecuted.ipynb
@@ -49,7 +49,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "The package environment has been created using **Julia 1.6** and may not\n",
+    "The package environment has been created using **Julia 1.7** and may not\n",
     "instantiate properly for other Julia versions."
    ],
    "metadata": {}

--- a/notebooks/03_pipelines/notebook.unexecuted.ipynb
+++ b/notebooks/03_pipelines/notebook.unexecuted.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "# Machine Learning in Julia"
+    "# Machine Learning in Julia (continued)"
    ],
    "metadata": {}
   },
@@ -195,7 +195,8 @@
    "outputs": [],
    "cell_type": "code",
    "source": [
-    "using UrlDownload, CSV, DataFrames\n",
+    "using UrlDownload, CSV\n",
+    "import DataFrames\n",
     "house_csv = urldownload(\"https://raw.githubusercontent.com/ablaom/\"*\n",
     "                        \"MachineLearningInJulia2020/for-MLJ-version-0.16/\"*\n",
     "                        \"data/house.csv\");\n",
@@ -211,7 +212,7 @@
    "outputs": [],
    "cell_type": "code",
    "source": [
-    "y, X = unpack(house, ==(:price), name -> true, rng=123);"
+    "y, X = unpack(house, ==(:price), rng=123);"
    ],
    "metadata": {},
    "execution_count": null
@@ -365,8 +366,8 @@
     "dimension-reducing models into a single model, known as a\n",
     "*pipeline*. While MLJ offers a powerful interface for composing\n",
     "models in a variety of ways, we'll stick to these simplest class of\n",
-    "composite models for now. The easiest way to construct them is using\n",
-    "the `@pipeline` macro:"
+    "composite models for now. The simplest way to construct a pipeline\n",
+    "is using the Julia's `|>` syntax:"
    ],
    "metadata": {}
   },
@@ -374,7 +375,7 @@
    "outputs": [],
    "cell_type": "code",
    "source": [
-    "pipe = @pipeline encoder reducer"
+    "pipe = encoder |> reducer"
    ],
    "metadata": {},
    "execution_count": null
@@ -382,15 +383,27 @@
   {
    "cell_type": "markdown",
    "source": [
-    "Notice that `pipe` is an *instance* of an automatically generated\n",
-    "type (called `Pipeline<some digits>`)."
+    "Notice that the model `pipe` has other models as hyperparameters\n",
+    "(with names automatically generated based on the mode type\n",
+    "name). The hyperparameters of the component models are are now\n",
+    "*nested*, but we can still access them:"
    ],
    "metadata": {}
   },
   {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "@show pipe.pca.pratio\n",
+    "pipe.pca.pratio = 0.85"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
    "cell_type": "markdown",
    "source": [
-    "The new model behaves like any other transformer:"
+    "The pipeline model behaves like any other transformer:"
    ],
    "metadata": {}
   },
@@ -419,7 +432,7 @@
    "source": [
     "RidgeRegressor = @load RidgeRegressor pkg=MLJLinearModels\n",
     "rgs = RidgeRegressor()\n",
-    "pipe2 = @pipeline encoder reducer rgs"
+    "pipe2 = pipe |> rgs"
    ],
    "metadata": {},
    "execution_count": null
@@ -545,12 +558,13 @@
   {
    "cell_type": "markdown",
    "source": [
-    "Next, suppose that instead of using the raw `:price` as the\n",
-    "training target, we want to use the log-price (a common practice in\n",
-    "dealing with house price data). However, suppose that we still want\n",
-    "to report final *predictions* on the original linear scale (and use\n",
-    "these for evaluation purposes). Then we supply appropriate functions\n",
-    "to key-word arguments `target` and `inverse`."
+    "Next, suppose that instead of using the raw `:price` as the training\n",
+    "target, we want to use the log-price (a common practice in dealing\n",
+    "with house price data). However, suppose that we still want to\n",
+    "report final *predictions* on the original linear scale (and use\n",
+    "these for evaluation purposes). Then we wrap our supervised model\n",
+    "using `TransformedTargetModel`, which has to key-word arguments\n",
+    "`target` and `inverse`."
    ],
    "metadata": {}
   },
@@ -582,7 +596,9 @@
    "outputs": [],
    "cell_type": "code",
    "source": [
-    "pipe3 = @pipeline encoder reducer rgs target=log inverse=exp\n",
+    "rgs_log = TransformedTargetModel(rgs, target=log, inverse=exp)\n",
+    "\n",
+    "pipe3 = pipe |> rgs_log\n",
     "mach = machine(pipe3, X, y)\n",
     "evaluate!(mach, measure=mae)"
    ],
@@ -617,7 +633,8 @@
     "box = UnivariateBoxCoxTransformer(n=20)\n",
     "stand = Standardizer()\n",
     "\n",
-    "pipe4 = @pipeline encoder reducer rgs target=box\n",
+    "rgs_box = TransformedTargetModel(rgs, target=box)\n",
+    "pipe4 = pipe |> rgs_box\n",
     "mach = machine(pipe4, X, y)\n",
     "evaluate!(mach, measure=mae)"
    ],
@@ -628,7 +645,7 @@
    "outputs": [],
    "cell_type": "code",
    "source": [
-    "pipe4.target = stand\n",
+    "pipe4.transformed_target_model_deterministic.target = stand\n",
     "evaluate!(mach, measure=mae)"
    ],
    "metadata": {},
@@ -692,7 +709,7 @@
     "        :outcome               => Multiclass,\n",
     "        :cp_data               => Multiclass);\n",
     "\n",
-    "y, X = unpack(horse, ==(:outcome), name -> true);\n",
+    "y, X = unpack(horse, ==(:outcome));\n",
     "schema(X)"
    ],
    "metadata": {},
@@ -754,11 +771,11 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.6.3"
+   "version": "1.7.1"
   },
   "kernelspec": {
-   "name": "julia-1.6",
-   "display_name": "Julia 1.6.3",
+   "name": "julia-1.7",
+   "display_name": "Julia 1.7.1",
    "language": "julia"
   }
  },


### PR DESCRIPTION
This includes the refactoring for non-macro pipelines, and using the new `TransformedTargetModel` wrapper.

It also adds an *executed* version of the jupyter notebook. 

